### PR TITLE
Improve portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .env
+node_modules
+*/node_modules
+frontend/frontend/build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Generador OFS
+
+Este proyecto contiene un backend en **Node.js** y un frontend en **React** para administrar órdenes de fabricación y generar archivos PDF.
+
+## Inicio rápido
+
+```bash
+# Backend
+cd backend/lxhapp
+npm install
+node server.js
+```
+
+```bash
+# Frontend
+cd frontend/frontend
+npm install
+npm start
+```
+
+El backend necesita un archivo `.env` con la configuración de la base de datos y la clave `JWT_SECRET`.
+

--- a/backend/lxhapp/routes/pdf.js
+++ b/backend/lxhapp/routes/pdf.js
@@ -5,7 +5,10 @@ const path = require("path");
 const fs = require("fs");
 
 const router = express.Router();
-const logoPath = "/home/esc/Descargas/Programas_Line-X/1.0.3/local/backend/templates/logo2.png";
+
+// Ruta a la carpeta de plantillas relativa al proyecto
+const templatesDir = path.join(__dirname, "..", "templates");
+const logoPath = path.join(templatesDir, "logo2.png");
 const logoBase64 = fs.readFileSync(logoPath).toString("base64");
 const logoSrc = `data:image/png;base64,${logoBase64}`;
 
@@ -34,8 +37,8 @@ router.post("/:id/pdf", async (req, res) => {
     const orden = ordenes[0];
 
     // **Seleccionar la plantilla correcta**
-    const plantillaNombre = cliente ? "plantilla2.html" : "plantilla.html";
-    const plantillaPath = path.join("/home/esc/Descargas/Programas_Line-X/1.0.3/local/backend/templates", plantillaNombre);
+  const plantillaNombre = cliente ? "plantilla2.html" : "plantilla.html";
+  const plantillaPath = path.join(templatesDir, plantillaNombre);
 
     // **Leer la plantilla HTML**
     let html = fs.readFileSync(plantillaPath, "utf8");


### PR DESCRIPTION
## Summary
- document quickstart instructions
- ignore node_modules globally
- use relative paths for PDF templates

## Testing
- `npm test` (fails: no test specified)
- `npm test` in frontend (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_68495128b8248321911e4153d716dc82