### PR TITLE
Improve Ordenes design

### DIFF
--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -4,6 +4,8 @@ import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useNavigate } from "react-router-dom";
 import { Modal, Button } from "react-bootstrap";
 import { useDropzone } from "react-dropzone";
+import "../styles/Ordenes.css";
+import { FolderOpen, User, Folder, FileText } from "lucide-react";
 
 
 
@@ -58,6 +60,42 @@ const Ordenes = () => {
     peso: "",
     notas: ""
   });
+
+  const generalFields = [
+    "nombre_proyecto",
+    "nombre_cliente",
+    "codigo_proyecto",
+    "responsable",
+    "figura",
+    "material",
+    "acabado",
+    "cantidad",
+    "unidad_medida",
+    "fecha_fin",
+    "peso",
+    "notas"
+  ];
+
+  const medidaFields = ["medida_v", "medida_w", "medida_h"];
+
+  const procesoFields = [
+    "fabric_pieza",
+    "post_mec",
+    "pegar_lijar",
+    "esculpir",
+    "line_x",
+    "fibra",
+    "mortero",
+    "aparejo",
+    "pintura",
+    "estructura",
+    "revisado"
+  ];
+
+  const formatLabel = (key) =>
+    key
+      .replace(/_/g, " ")
+      .replace(/\b\w/g, (l) => l.toUpperCase());
 
   useEffect(() => {
     if (!token) {
@@ -219,12 +257,14 @@ const Ordenes = () => {
     
   };
   return (
-    
-    <div className="container-fluid">
+
+    <div className="ordenes-wrapper container-fluid">
       <div className="row">
         {/* Sidebar */}
-        <div className="col-md-3 bg-dark text-white p-3 rounded" style={{ minHeight: "auto", maxHeight: "80vh", overflowY: "auto" }}>
-  <h4 className="text-center">📂 Tus órdenes por cliente</h4>
+        <div className="col-md-3 ordenes-sidebar">
+  <h4 className="text-center d-flex align-items-center justify-content-center gap-2">
+    <FolderOpen size={20} /> Tus órdenes por cliente
+  </h4>
   <button 
     className="btn btn-light text-dark w-100 mb-3" 
     onClick={resetForm}
@@ -245,7 +285,7 @@ const Ordenes = () => {
             aria-expanded="false"
             aria-controls={`clienteCollapse-${cliente.cliente?.id || i}`}
             >
-            👤 {cliente.cliente?.nombre_cliente}
+            <User size={16} className="me-2" /> {cliente.cliente?.nombre_cliente}
           </button>
         </h2>
         <div
@@ -268,7 +308,7 @@ const Ordenes = () => {
           aria-controls={`collapseProyecto-${i}-${j}`}
           style={{ fontSize: "0.9rem" }}
         >
-          📁 {proyecto.proyecto?.nombre_proyecto}
+          <Folder size={16} className="me-2" /> {proyecto.proyecto?.nombre_proyecto}
         </button>
       </h2>
       <div
@@ -282,7 +322,7 @@ const Ordenes = () => {
             {proyecto.ordenes.map((orden, k) => (
               <li
                 key={k}
-                className={`list-group-item bg-dark text-white border-0 ps-4 ${
+                className={`list-group-item bg-dark text-white border-0 ps-4 d-flex align-items-center ${
                   ordenSeleccionada?.id === orden.id ? "active bg-primary" : ""
                 }`}
                 style={{ cursor: "pointer" }}
@@ -299,7 +339,7 @@ const Ordenes = () => {
                   setForm(ordenEditable);
                 }}
               >
-                🧾 {orden.figura}
+                <FileText size={16} className="me-2" /> {orden.figura}
               </li>
             ))}
           </ul>
@@ -318,7 +358,7 @@ const Ordenes = () => {
 
 
         {/* Formulario Mejorado */}
-        <div className="col p-4">
+        <div className="col ordenes-form-card">
           <div className="card shadow p-4">
             {/* Título centrado */}
             <h4 className="mb-4 text-center">
@@ -326,93 +366,123 @@ const Ordenes = () => {
             </h4>
 
             <form onSubmit={handleSubmit}>
-            <div className="row">
-  {Object.keys(form).map((key) => (
-    <div className="col-md-6 mb-3" key={key}>
-      <label className="form-label">{key.replace("_", " ").toUpperCase()}</label>
+              <div className="row">
+                {generalFields.map((key) => (
+                  <div className="col-md-6 mb-3" key={key}>
+                    <label className="form-label">{formatLabel(key)}</label>
+                    {key === "codigo_proyecto" ? (
+                      <input
+                        type="text"
+                        className="form-control bg-light"
+                        name={key}
+                        value={form[key]}
+                        readOnly
+                      />
+                    ) : key === "unidad_medida" ? (
+                      <select
+                        className="form-control"
+                        name={key}
+                        value={form[key]}
+                        onChange={handleChange}
+                        required
+                      >
+                        <option value="">Selecciona una opción</option>
+                        <option value="mm">Milímetros (mm)</option>
+                        <option value="cm">Centímetros (cm)</option>
+                        <option value="m">Metros (m)</option>
+                      </select>
+                    ) : (
+                      <input
+                        type={key.includes("fecha") ? "date" : key === "cantidad" ? "number" : "text"}
+                        className="form-control"
+                        name={key}
+                        value={form[key]}
+                        onChange={handleChange}
+                        required
+                      />
+                    )}
+                  </div>
+                ))}
+              </div>
 
-      {[
-        "fabric_pieza",
-        "post_mec",
-        "pegar_lijar",
-        "esculpir",
-        "line_x",
-        "fibra",
-        "mortero",
-        "aparejo",
-        "pintura",
-        "estructura",
-      ].includes(key) ? (
-        <div className="form-check form-switch">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id={key}
-            name={key}
-            checked={form[key] === "Sí"}
-            onChange={(e) => setForm({ ...form, [key]: e.target.checked ? "Sí" : "No" })}
-          />
-          <label className="form-check-label" htmlFor={key}>
-            {form[key] === "Sí" ? "Sí" : "No"}
-          </label>
-        </div>
-      ) : key === "codigo_proyecto" ? (
-        <input
-          type="text"
-          className="form-control bg-light"
-          name={key}
-          value={form[key]}
-          readOnly
-        />
-      ) : key === "unidad_medida" ? (
-        <select className="form-control" name={key} value={form[key]} onChange={handleChange} required>
-          <option value="">Selecciona una opción</option>
-          <option value="mm">Milímetros (mm)</option>
-          <option value="cm">Centímetros (cm)</option>
-          <option value="m">Metros (m)</option>
-        </select>
-      ) : (
-        <input
-          type={key.includes("fecha") ? "date" : key === "cantidad" ? "number" : "text"}
-          className="form-control"
-          name={key}
-          value={form[key]}
-          onChange={handleChange}
-          required
-        />
-      )}
-    </div>
-  ))}
-</div>
-              {/* Botones centrados */}
+              <h6 className="section-title">Medidas</h6>
+              <div className="row">
+                {medidaFields.map((key) => (
+                  <div className="col-md-4 mb-3" key={key}>
+                    <label className="form-label">{formatLabel(key)}</label>
+                    <input
+                      type="text"
+                      className="form-control"
+                      name={key}
+                      value={form[key]}
+                      onChange={handleChange}
+                      required
+                    />
+                  </div>
+                ))}
+              </div>
+
+              <h6 className="section-title">Procesos</h6>
+              <div className="row">
+                {procesoFields.map((key) => (
+                  <div className="col-md-4 mb-3" key={key}>
+                    <label className="form-label">{formatLabel(key)}</label>
+                    <div className="form-check form-switch">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id={key}
+                        name={key}
+                        checked={form[key] === "Sí"}
+                        onChange={(e) =>
+                          setForm({ ...form, [key]: e.target.checked ? "Sí" : "No" })
+                        }
+                      />
+                      <label className="form-check-label" htmlFor={key}>
+                        {form[key] === "Sí" ? "Sí" : "No"}
+                      </label>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
               <div className="d-flex justify-content-center mt-3 flex-wrap">
                 <button className="btn btn-success me-2" type="submit">
                   {ordenSeleccionada ? "Actualizar" : "Crear"}
                 </button>
-                
                 {ordenSeleccionada && (
                   <>
-                    <button className="btn btn-danger me-2" type="button" onClick={handleDelete}>
+                    <button
+                      className="btn btn-danger me-2"
+                      type="button"
+                      onClick={handleDelete}
+                    >
                       Eliminar
                     </button>
-                    <form onSubmit={handleSubmit}>
                     <Button className="btn btn-secondary me-2" onClick={() => setShowModal(true)}>
                       Añadir imágenes
                     </Button>
-                      <button className="btn btn-primary me-2" type="button" onClick={() => handleDownloadPDF(ordenSeleccionada.id)}>
-                        OF
-                      </button>
-                    </form>
-                    <button className="btn btn-primary me-2" type="button" onClick={() => handleDownloadPDF(ordenSeleccionada.id, true)}>
+                    <button
+                      className="btn btn-primary me-2"
+                      type="button"
+                      onClick={() => handleDownloadPDF(ordenSeleccionada.id)}
+                    >
+                      OF
+                    </button>
+                    <button
+                      className="btn btn-primary me-2"
+                      type="button"
+                      onClick={() => handleDownloadPDF(ordenSeleccionada.id, true)}
+                    >
                       OF Cliente
                     </button>
-
                     <button className="btn btn-primary" type="button">
                       OT
                     </button>
                   </>
                 )}
               </div>
+            </form>
               <Modal show={showModal} onHide={() => setShowModal(false)} size="lg">
   <Modal.Header closeButton>
     <Modal.Title>Seleccionar Imágenes</Modal.Title>
@@ -474,7 +544,6 @@ const Ordenes = () => {
     </Button>
   </Modal.Footer>
 </Modal>
-            </form>
           </div>
         </div>
       </div>

--- a/frontend/frontend/src/styles/Ordenes.css
+++ b/frontend/frontend/src/styles/Ordenes.css
@@ -1,0 +1,52 @@
+.ordenes-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.ordenes-sidebar {
+  background: #343a40;
+  color: #fff;
+  max-height: 80vh;
+  overflow-y: auto;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.ordenes-sidebar .accordion-button {
+  background-color: #495057;
+  color: #fff;
+}
+
+.ordenes-sidebar .accordion-button.collapsed {
+  background-color: #343a40;
+}
+
+.ordenes-sidebar .accordion-button:focus {
+  box-shadow: none;
+}
+
+.ordenes-sidebar .list-group-item {
+  background-color: #343a40;
+}
+
+.ordenes-sidebar .list-group-item:hover {
+  background-color: #495057;
+}
+
+.ordenes-form-card {
+  padding: 1rem;
+}
+
+.ordenes-form-card .card {
+  border: none;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.section-title {
+  border-bottom: 1px solid #dee2e6;
+  font-weight: 500;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- add Ordenes.css with new layout styles
- reorganize Ordenes.jsx form layout and sidebar
- group form inputs by section and add helper utils
- update sidebar and form container classes
- **improve sidebar icons**

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498aebdd5483218ac9c9487cdf8fc4