### PR TITLE
Add search and save images

### DIFF
--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -18,6 +18,7 @@ const Ordenes = () => {
   const [imagenes, setImagenes] = useState([]); // Estado para almacenar imágenes en Base64
   const [showModal, setShowModal] = useState(false);
   const [imagenesModal, setImagenesModal] = useState({ grande: null, pequenas: [null, null, null, null] });
+  const [busqueda, setBusqueda] = useState("");
 
   const generarCodigoProyecto = () => {
     const letras = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -110,6 +111,21 @@ const Ordenes = () => {
   }, [token, navigate]);
 
   const [ordenesTree, setOrdenesTree] = useState([]);
+  const filteredOrdenesTree = ordenesTree
+    .map((cliente) => ({
+      ...cliente,
+      proyectos: cliente.proyectos
+        .map((proyecto) => ({
+          ...proyecto,
+          ordenes: proyecto.ordenes.filter(
+            (o) =>
+              o.figura.toLowerCase().includes(busqueda.toLowerCase()) ||
+              (o.codigo_proyecto || "").toLowerCase().includes(busqueda.toLowerCase())
+          ),
+        }))
+        .filter((p) => p.ordenes.length > 0),
+    }))
+    .filter((c) => c.proyectos.length > 0);
 
   useEffect(() => {
     axios
@@ -263,21 +279,29 @@ const Ordenes = () => {
       <div className="row">
         {/* Sidebar */}
         <div className="col-md-3 ordenes-sidebar">
-  <h4 className="text-center d-flex align-items-center justify-content-center gap-2">
-    <FolderOpen size={20} /> Tus órdenes por cliente
-  <h4 className="text-center">📂 Tus órdenes por cliente</h4>
+          <h4 className="text-center d-flex align-items-center justify-content-center gap-2">
+            <FolderOpen size={20} /> Tus órdenes por cliente
+          </h4>
 
-  <button 
-    className="btn btn-light text-dark w-100 mb-3" 
-    onClick={resetForm}
-  >
-    Crear orden
-  </button>
+          <button
+            className="btn btn-light text-dark w-100 mb-3"
+            onClick={resetForm}
+          >
+            Crear orden
+          </button>
 
-  {/* Aquí va el nuevo árbol */}
-  <div className="accordion" id="ordenesAccordion">
-    {ordenesTree.map((cliente, i) => (
-      <div className="accordion-item bg-dark border-0 text-white" key={i}>
+          <input
+            type="text"
+            className="form-control mb-3"
+            placeholder="Buscar OF"
+            value={busqueda}
+            onChange={(e) => setBusqueda(e.target.value)}
+          />
+
+          {/* Aquí va el nuevo árbol */}
+          <div className="accordion" id="ordenesAccordion">
+            {filteredOrdenesTree.map((cliente, i) => (
+              <div className="accordion-item bg-dark border-0 text-white" key={i}>
         <h2 className="accordion-header" id={`heading-${cliente.cliente?.id || i}`}>
           <button
             className="accordion-button bg-secondary text-white collapsed"
@@ -539,6 +563,11 @@ const Ordenes = () => {
       onClick={() => {
         const todas = [imagenesModal.grande, ...imagenesModal.pequenas.filter(Boolean)];
         setImagenes(todas);
+        if (ordenSeleccionada) {
+          axios
+            .post(`http://localhost:3000/ordenes/${ordenSeleccionada.id}/imagenes`, { imagenes: todas })
+            .catch((err) => console.error('Error guardando imágenes', err));
+        }
         setShowModal(false);
       }}
     >

--- a/frontend/frontend/src/styles/Ordenes.css
+++ b/frontend/frontend/src/styles/Ordenes.css
@@ -4,7 +4,7 @@
 }
 
 .ordenes-sidebar {
-  background: #343a40;
+  background: linear-gradient(135deg, #007bff, #6610f2);
   color: #fff;
   max-height: 80vh;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- allow filtering orders by project code or figure name
- recolor orders sidebar to match dashboard blue theme
- save uploaded images in backend for each order

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684992c561608321a18e292d93ea9c90