### PR TITLE
Fix missing search and accordion wrapper in Ordenes.jsx

### DIFF
--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -289,8 +289,17 @@ const Ordenes = () => {
           >
             Crear orden
           </button>
+          <input
+            type="text"
+            className="form-control mb-3"
+            placeholder="Buscar OF"
+            value={busqueda}
+            onChange={(e) => setBusqueda(e.target.value)}
+          />
 
-
+          {/* Aquí va el nuevo árbol */}
+          <div className="accordion" id="ordenesAccordion">
+            {filteredOrdenesTree.map((cliente, i) => (
               <div className="accordion-item bg-dark border-0 text-white" key={i}>
         <h2 className="accordion-header" id={`heading-${cliente.cliente?.id || i}`}>
           <button


### PR DESCRIPTION
## Summary
- restore search box and accordion wrapper in `Ordenes.jsx`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849962d9eb48321b5803973d918495b