### PR TITLE
Enable profile editing with avatar upload

### DIFF
--- a/backend/lxhapp/routes/ordenes.js
+++ b/backend/lxhapp/routes/ordenes.js
@@ -108,26 +108,26 @@ router.put('/:id', verificarToken, async (req, res) => {
     const {
         nombre_cliente, responsable, figura, medida_v, medida_w, medida_h,
         unidad_medida, material, acabado, cantidad, fabric_pieza, post_mec,
-        pegar_lijar, esculpir, line_x, fibra, mortero, aparejo, pintura, estructura, revisado, fecha_fin, notas, peso
+        pegar_lijar, esculpir, line_x, fibra, mortero, aparejo, pintura, estructura,
+        revisado, fecha_inicio, fecha_fin, notas, peso
     } = req.body;
 
     try {
         const [result] = await pool.query(
-            `UPDATE ordenes SET 
-                nombre_cliente = ?, responsable = ?, figura = ?, medida_v = ?, 
-                medida_w = ?, medida_h = ?, unidad_medida = ?, material = ?, acabado = ?, 
-                cantidad = ?, fabric_pieza = ?, post_mec = ?, pegar_lijar = ?, esculpir = ?, 
-                line_x = ?, fibra = ?, mortero = ?, aparejo = ?, pintura = ?, estructura = ?, 
-                revisado = ?, fecha_fin = ?, peso = ?, notas = ?
-                WHERE id = ? AND usuario_id = ?`
-                ,
+            `UPDATE ordenes SET
+                nombre_cliente = ?, responsable = ?, figura = ?, medida_v = ?,
+                medida_w = ?, medida_h = ?, unidad_medida = ?, material = ?, acabado = ?,
+                cantidad = ?, fabric_pieza = ?, post_mec = ?, pegar_lijar = ?, esculpir = ?,
+                line_x = ?, fibra = ?, mortero = ?, aparejo = ?, pintura = ?, estructura = ?,
+                revisado = ?, fecha_inicio = ?, fecha_fin = ?, peso = ?, notas = ?
+                WHERE id = ? AND usuario_id = ?`,
                 [
                     nombre_cliente, responsable, figura, medida_v, medida_w, medida_h, unidad_medida,
                     material, acabado, cantidad, fabric_pieza, post_mec, pegar_lijar, esculpir,
-                    line_x, fibra, mortero, aparejo, pintura, estructura, revisado, fecha_fin,
-                    peso, notas, id, usuario_id
+                    line_x, fibra, mortero, aparejo, pintura, estructura, revisado, fecha_inicio,
+                    fecha_fin, peso, notas, id, usuario_id
                 ]
-                  
+
         );
 
         if (result.affectedRows > 0) {

--- a/backend/lxhapp/routes/userRoutes.js
+++ b/backend/lxhapp/routes/userRoutes.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const { verificarToken, verificarRol } = require('../middlewares/auth');
 const pool = require('../db');  // Asegúrate de importar la conexión a la BD
+const bcrypt = require('bcryptjs');
+const fs = require('fs');
+const path = require('path');
 const router = express.Router();
 const projectController = require('../controllers/project.controller');
 
@@ -9,13 +12,68 @@ router.get('/:username', verificarToken, async (req, res) => {
     const { username } = req.params;  // Obtener el nombre de usuario desde la URL
 
     try {
-        const [rows] = await pool.query('SELECT id, email, nombre FROM usuarios WHERE nombre = ?', [username]);
+        const [rows] = await pool.query('SELECT id, email, nombre, avatar FROM usuarios WHERE nombre = ?', [username]);
 
         if (rows.length === 0) {
             return res.status(404).json({ mensaje: 'Usuario no encontrado' });
         }
 
         res.json(rows[0]);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ mensaje: 'Error en el servidor' });
+    }
+});
+
+// Actualizar perfil
+router.put('/:username', verificarToken, async (req, res) => {
+    const { username } = req.params;
+    const { nombre, email, password, avatar } = req.body;
+
+    try {
+        const [rows] = await pool.query('SELECT * FROM usuarios WHERE nombre = ?', [username]);
+        if (rows.length === 0) {
+            return res.status(404).json({ mensaje: 'Usuario no encontrado' });
+        }
+        const usuario = rows[0];
+        if (usuario.id !== req.usuario.id) {
+            return res.status(403).json({ mensaje: 'No autorizado' });
+        }
+
+        const fields = [];
+        const values = [];
+
+        if (nombre) { fields.push('nombre = ?'); values.push(nombre); }
+        if (email) { fields.push('email = ?'); values.push(email); }
+        if (password) {
+            const hashed = await bcrypt.hash(password, 10);
+            fields.push('password = ?');
+            values.push(hashed);
+        }
+
+        let avatarPath = usuario.avatar;
+        if (avatar) {
+            const dir = path.join(__dirname, '..', 'uploads', 'avatars');
+            await fs.promises.mkdir(dir, { recursive: true });
+            const match = avatar.match(/^data:image\/(\w+);base64,/);
+            const ext = match ? match[1] : 'png';
+            const base64Data = avatar.replace(/^data:image\/\w+;base64,/, '');
+            const fileName = `${usuario.id}.${ext}`;
+            const filePath = path.join(dir, fileName);
+            await fs.promises.writeFile(filePath, base64Data, 'base64');
+            avatarPath = `/avatars/${fileName}`;
+            fields.push('avatar = ?');
+            values.push(avatarPath);
+        }
+
+        if (fields.length === 0) {
+            return res.json({ mensaje: 'Sin cambios' });
+        }
+        values.push(usuario.id);
+        const sql = `UPDATE usuarios SET ${fields.join(', ')} WHERE id = ?`;
+        await pool.query(sql, values);
+
+        res.json({ mensaje: 'Perfil actualizado', avatar: avatarPath });
     } catch (error) {
         console.error(error);
         res.status(500).json({ mensaje: 'Error en el servidor' });

--- a/backend/lxhapp/server.js
+++ b/backend/lxhapp/server.js
@@ -4,6 +4,7 @@ const pool = require('./db'); // Conexión a MySQL
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const cors = require('cors');
+const path = require('path');
 const userRoutes = require('./routes/userRoutes');
 const ordenesRoutes = require('./routes/ordenes');
 const pdfRoutes = require("./routes/pdf"); // PDF
@@ -17,6 +18,7 @@ app.use(bodyParser.urlencoded({ limit: "50mb", extended: true }));
 
 app.use(express.json());
 app.use(cors()); // CORS habilitado antes de rutas
+app.use('/avatars', express.static(path.join(__dirname, 'uploads', 'avatars')));
 
 // 📌 **Rutas**
 app.use('/usuarios', userRoutes);
@@ -33,8 +35,8 @@ app.post('/register', async (req, res) => {
 
     try {
         const hashedPassword = await bcrypt.hash(password, 10);
-        await pool.query('INSERT INTO usuarios (nombre, email, password, rol) VALUES (?, ?, ?, ?)', 
-            [nombre, email, hashedPassword, rol]);
+        await pool.query('INSERT INTO usuarios (nombre, email, password, rol, avatar) VALUES (?, ?, ?, ?, ?)',
+            [nombre, email, hashedPassword, rol, null]);
 
         res.json({ mensaje: 'Usuario registrado con éxito' });
     } catch (error) {
@@ -67,8 +69,8 @@ app.post('/login', async (req, res) => {
             { expiresIn: '8h' }
         );
 
-        // 🔥 Ahora enviamos el "nombre" en la respuesta JSON
-        res.json({ mensaje: 'Login exitoso', token, rol: usuario.rol, nombre: usuario.nombre });
+        // 🔥 Ahora enviamos el "nombre" y el avatar en la respuesta JSON
+        res.json({ mensaje: 'Login exitoso', token, rol: usuario.rol, nombre: usuario.nombre, avatar: usuario.avatar });
     } catch (error) {
         console.error(error);
         res.status(500).json({ mensaje: 'Error en el servidor' });

--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useNavigate } from "react-router-dom";
-import { Modal, Button } from "react-bootstrap";
+import { Modal, Button, Spinner } from "react-bootstrap";
 import { useDropzone } from "react-dropzone";
 import "../styles/Ordenes.css";
 import { FolderOpen, User, Folder, FileText } from "lucide-react";
@@ -19,6 +19,7 @@ const Ordenes = () => {
   const [showModal, setShowModal] = useState(false);
   const [imagenesModal, setImagenesModal] = useState({ grande: null, pequenas: [null, null, null, null] });
   const [busqueda, setBusqueda] = useState("");
+  const [loadingPDF, setLoadingPDF] = useState(false);
 
   const generarCodigoProyecto = () => {
     const letras = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -58,6 +59,7 @@ const Ordenes = () => {
     pintura: "",
     estructura: "",
     revisado: "",
+    fecha_inicio: "",
     fecha_fin: "",
     peso: "",
     notas: ""
@@ -73,6 +75,7 @@ const Ordenes = () => {
     "acabado",
     "cantidad",
     "unidad_medida",
+    "fecha_inicio",
     "fecha_fin",
     "peso",
     "notas"
@@ -94,10 +97,12 @@ const Ordenes = () => {
     "revisado"
   ];
 
-  const formatLabel = (key) =>
-    key
+  const formatLabel = (key) => {
+    if (key === "medida_v") return "Medida L";
+    return key
       .replace(/_/g, " ")
       .replace(/\b\w/g, (l) => l.toUpperCase());
+  };
 
   useEffect(() => {
     if (!token) {
@@ -229,6 +234,7 @@ const Ordenes = () => {
       pintura: "",
       estructura: "",
       revisado: "",
+      fecha_inicio: "",
       fecha_fin: "",
       peso: "",
       notas: ""
@@ -242,10 +248,11 @@ const Ordenes = () => {
       alert("Faltan datos necesarios para generar el PDF");
       return;
     }
-  
+
     const url = `http://localhost:3000/ordenes/${id}/pdf${cliente ? "?cliente=true" : ""}`;
-  
+
     try {
+      setLoadingPDF(true);
       const response = await fetch(url, {
         method: "POST",
         headers: {
@@ -270,8 +277,10 @@ const Ordenes = () => {
     } catch (error) {
       console.error("Error al descargar el PDF:", error);
       alert("Error al descargar el PDF");
+    } finally {
+      setLoadingPDF(false);
     }
-    
+
   };
   return (
 
@@ -357,7 +366,6 @@ const Ordenes = () => {
                     usuario_id,
                     fecha_creacion,
                     fecha_actualizacion,
-                    fecha_inicio,
                     ...ordenEditable
                   } = orden;
                   setOrdenSeleccionada(orden);
@@ -491,15 +499,17 @@ const Ordenes = () => {
                       className="btn btn-primary me-2"
                       type="button"
                       onClick={() => handleDownloadPDF(ordenSeleccionada.id)}
+                      disabled={loadingPDF}
                     >
-                      OF
+                      {loadingPDF ? <Spinner size="sm" animation="border" /> : "OF"}
                     </button>
                     <button
                       className="btn btn-primary me-2"
                       type="button"
                       onClick={() => handleDownloadPDF(ordenSeleccionada.id, true)}
+                      disabled={loadingPDF}
                     >
-                      OF Cliente
+                      {loadingPDF ? <Spinner size="sm" animation="border" /> : "OF Cliente"}
                     </button>
                     <button className="btn btn-primary" type="button">
                       OT


### PR DESCRIPTION
## Summary
- serve avatars from backend
- include avatar field in registration and login
- add profile update route with avatar upload
- show profile avatar in dashboard and add modals to view or edit profile

## Testing
- `npm test` in `frontend/frontend` *(fails: react-scripts not found)*
- `npm test` in `backend/lxhapp` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684999bd7974832185eed52940a075e4