### PR TITLE
Add stats panel and fix sidebar

### DIFF
--- a/frontend/frontend/package.json
+++ b/frontend/frontend/package.json
@@ -20,6 +20,8 @@
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.1",
     "react-router-dom": "^7.3.0",
     "react-scripts": "5.0.1",
     "source-map-loader": "^5.0.0",

--- a/frontend/frontend/src/apps/Estadisticas.jsx
+++ b/frontend/frontend/src/apps/Estadisticas.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Bar, Pie } from 'react-chartjs-2';
+import Chart from 'chart.js/auto';
+
+const Estadisticas = () => {
+  const [ordenes, setOrdenes] = useState([]);
+  const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    if (!token) return;
+    axios
+      .get('http://localhost:3000/ordenes', { headers: { Authorization: `Bearer ${token}` } })
+      .then((res) => setOrdenes(res.data))
+      .catch((err) => console.error('Error al cargar estadísticas:', err));
+  }, [token]);
+
+  const totalOrdenes = ordenes.length;
+  const porMaterial = {};
+  const porResponsable = {};
+  ordenes.forEach((o) => {
+    if (o.material) {
+      porMaterial[o.material] = (porMaterial[o.material] || 0) + 1;
+    }
+    if (o.responsable) {
+      porResponsable[o.responsable] = (porResponsable[o.responsable] || 0) + 1;
+    }
+  });
+
+  const materiales = Object.keys(porMaterial);
+  const materialCounts = Object.values(porMaterial);
+
+  const responsables = Object.keys(porResponsable);
+  const responsableCounts = Object.values(porResponsable);
+
+  const pieData = {
+    labels: materiales,
+    datasets: [
+      {
+        data: materialCounts,
+        backgroundColor: [
+          '#007bff',
+          '#28a745',
+          '#dc3545',
+          '#ffc107',
+          '#17a2b8',
+          '#6610f2',
+        ],
+      },
+    ],
+  };
+
+  const barData = {
+    labels: responsables,
+    datasets: [
+      {
+        label: 'Órdenes por responsable',
+        data: responsableCounts,
+        backgroundColor: '#007bff',
+      },
+    ],
+  };
+
+  return (
+    <div className="stats-panel">
+      <h2 className="mb-4">Estadísticas de Órdenes</h2>
+      <p>Total de órdenes: {totalOrdenes}</p>
+      <div className="row">
+        <div className="col-md-6 mb-4">
+          <h5 className="text-center">Órdenes por material</h5>
+          <Pie data={pieData} />
+        </div>
+        <div className="col-md-6 mb-4">
+          <h5 className="text-center">Órdenes por responsable</h5>
+          <Bar data={barData} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Estadisticas;

--- a/frontend/frontend/src/pages/Dashboard.jsx
+++ b/frontend/frontend/src/pages/Dashboard.jsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "../styles/Dashboard.css";
 import Ordenes from "../apps/Ordenes";
+import Estadisticas from "../apps/Estadisticas";
 import { Modal, Button } from "react-bootstrap";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
@@ -157,18 +158,7 @@ const Dashboard = () => {
           {appSeleccionada === "ordenes" && <Ordenes />}
           {appSeleccionada === "aplicacion2" && <h2>Aplicación 2</h2>}
           {appSeleccionada === "aplicacion3" && <h2>Aplicación 3</h2>}
-          {appSeleccionada === "Inicio" && (
-      <div class="patch-notes">
-          <h2>Versión 1.0.1</h2>
-          <ul>
-            <li>Mejoras en el rendimiento del dashboard</li>
-            <li>Nuevo diseño de bienvenida</li>
-            <li>Corrección de errores menores</li>
-            <li>Implementacion y correcion de errores al lanzar OF</li>
-            <b><li>¡YA PUEDEN GENERAR OF CLIENTE!</li></b>
-          </ul>
-      </div>
-          )}
+          {appSeleccionada === "Inicio" && <Estadisticas />}
         </div>
       </div>
       {/* Modales de perfil */}

--- a/frontend/frontend/src/styles/Dashboard.css
+++ b/frontend/frontend/src/styles/Dashboard.css
@@ -23,6 +23,7 @@
   width: 0;
   padding: 0;
   overflow: hidden;
+  display: none;
 }
 
 .sidebar.collapsed .logo,
@@ -132,6 +133,21 @@
 .patch-notes b li {
   color: #007bff;
   font-weight: bold;
+}
+
+/* Estadísticas */
+.stats-panel {
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.stats-panel h2 {
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #333;
 }
 
 /* Animación */


### PR DESCRIPTION
## Summary
- add Estadisticas app with charts using Chart.js
- replace patch notes in Dashboard with statistics panel
- hide sidebar fully when collapsed
- style statistics panel
- include chart libraries in frontend package.json

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7b358190832babdcc61947e5fbc2