### PR TITLE
Fix date edit view

### DIFF
--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -375,8 +375,19 @@ const Ordenes = () => {
                     fecha_actualizacion,
                     ...ordenEditable
                   } = orden;
+                  const editableCopy = { ...ordenEditable };
+                  if (editableCopy.fecha_inicio) {
+                    editableCopy.fecha_inicio = new Date(editableCopy.fecha_inicio)
+                      .toISOString()
+                      .slice(0, 10);
+                  }
+                  if (editableCopy.fecha_fin) {
+                    editableCopy.fecha_fin = new Date(editableCopy.fecha_fin)
+                      .toISOString()
+                      .slice(0, 10);
+                  }
                   setOrdenSeleccionada(orden);
-                  setForm(ordenEditable);
+                  setForm(editableCopy);
                 }}
               >
                 <FileText size={16} className="me-2" /> {orden.figura}


### PR DESCRIPTION
## Summary
- ensure date inputs show existing values when editing orders

## Testing
- `npm test --prefix frontend/frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a88f8c67c832b98ef40d67e5539fe