### PR TITLE
Improve sidebar and accordion styling

### DIFF
--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -316,10 +316,10 @@ const Ordenes = () => {
           {/* Aquí va el nuevo árbol */}
           <div className="accordion" id="ordenesAccordion">
             {filteredOrdenesTree.map((cliente, i) => (
-              <div className="accordion-item bg-dark border-0 text-white" key={i}>
+              <div className="accordion-item border-0 text-white" key={i}>
         <h2 className="accordion-header" id={`heading-${cliente.cliente?.id || i}`}>
           <button
-            className="accordion-button bg-secondary text-white collapsed"
+            className="accordion-button text-white collapsed"
             type="button"
             data-bs-toggle="collapse"
             data-bs-target={`#clienteCollapse-${cliente.cliente?.id || i}`}
@@ -338,10 +338,10 @@ const Ordenes = () => {
           <div className="accordion-body">
           <div className="accordion" id={`proyectosAccordion-${i}`}>
   {cliente.proyectos.map((proyecto, j) => (
-    <div className="accordion-item bg-dark text-white border-0" key={j}>
+    <div className="accordion-item border-0 text-white" key={j}>
       <h2 className="accordion-header" id={`headingProyecto-${i}-${j}`}>
         <button
-          className="accordion-button bg-dark text-warning collapsed"
+          className="accordion-button text-warning collapsed"
           type="button"
           data-bs-toggle="collapse"
           data-bs-target={`#collapseProyecto-${i}-${j}`}
@@ -363,7 +363,7 @@ const Ordenes = () => {
             {proyecto.ordenes.map((orden, k) => (
               <li
                 key={k}
-                className={`list-group-item bg-dark text-white border-0 ps-4 d-flex align-items-center ${
+                className={`list-group-item bg-transparent text-white border-0 ps-4 d-flex align-items-center ${
                   ordenSeleccionada?.id === orden.id ? "active bg-primary" : ""
                 }`}
                 style={{ cursor: "pointer" }}

--- a/frontend/frontend/src/pages/Dashboard.jsx
+++ b/frontend/frontend/src/pages/Dashboard.jsx
@@ -17,7 +17,7 @@ const Dashboard = () => {
   const [showPerfil, setShowPerfil] = useState(false);
   const [showEditar, setShowEditar] = useState(false);
   const [editData, setEditData] = useState({ nombre: "", email: "", password: "", avatar: null });
-  const [appSeleccionada, setAppSeleccionada] = useState("Inicio");
+  const [appSeleccionada, setAppSeleccionada] = useState("estadisticas");
   const [menuAbierto, setMenuAbierto] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const dropdownRef = useRef(null);
@@ -109,7 +109,24 @@ const Dashboard = () => {
   <ul className="nav flex-column align-items-center">
     <li className="nav-item">
       <button
-        className="nav-link text-white btn btn-link w-100 text-center p-2"
+        className={`nav-link text-white btn btn-link w-100 text-center p-2 ${appSeleccionada === 'estadisticas' ? 'active' : ''}`}
+        onClick={() => setAppSeleccionada('estadisticas')}
+        style={{
+          transition: 'background-color 0.3s, transform 0.2s',
+          border: 'none',
+          textAlign: 'center',
+        }}
+        onMouseEnter={(e) => e.target.style.backgroundColor = '#575757'}
+        onMouseLeave={(e) => e.target.style.backgroundColor = 'transparent'}
+        onMouseDown={(e) => e.target.style.transform = 'scale(0.98)'}
+        onMouseUp={(e) => e.target.style.transform = 'scale(1)'}
+      >
+        Estadísticas
+      </button>
+    </li>
+    <li className="nav-item">
+      <button
+        className={`nav-link text-white btn btn-link w-100 text-center p-2 ${appSeleccionada === 'ordenes' ? 'active' : ''}`}
         onClick={() => setAppSeleccionada("ordenes")}
         style={{
           transition: 'background-color 0.3s, transform 0.2s',
@@ -126,7 +143,7 @@ const Dashboard = () => {
     </li>
     <li className="nav-item">
       <button
-        className="nav-link text-white btn btn-link w-100 text-center p-2"
+        className={`nav-link text-white btn btn-link w-100 text-center p-2 ${appSeleccionada === 'externas' ? 'active' : ''}`}
         onClick={() => setAppSeleccionada("externas")}
         style={{
           transition: 'background-color 0.3s, transform 0.2s',
@@ -143,7 +160,7 @@ const Dashboard = () => {
     </li>
     <li className="nav-item">
       <button
-        className="nav-link text-white btn btn-link w-100 text-center p-2"
+        className={`nav-link text-white btn btn-link w-100 text-center p-2 ${appSeleccionada === 'verofs' ? 'active' : ''}`}
         onClick={() => setAppSeleccionada("verofs")}
         style={{
           transition: 'background-color 0.3s, transform 0.2s',
@@ -196,7 +213,7 @@ const Dashboard = () => {
           {appSeleccionada === "verofs" && <VerOFs />}
           {appSeleccionada === "aplicacion2" && <h2>Aplicación 2</h2>}
           {appSeleccionada === "aplicacion3" && <h2>Aplicación 3</h2>}
-          {appSeleccionada === "Inicio" && <Estadisticas />}
+          {appSeleccionada === "estadisticas" && <Estadisticas />}
         </div>
       </div>
       {/* Modales de perfil */}

--- a/frontend/frontend/src/styles/Dashboard.css
+++ b/frontend/frontend/src/styles/Dashboard.css
@@ -58,6 +58,11 @@
   transform: scale(1.03);
 }
 
+.sidebar .nav .nav-item .nav-link.active {
+  background: rgba(255, 255, 255, 0.3);
+  font-weight: 700;
+}
+
 /* Main Content */
 .main-content {
   margin-left: 240px;

--- a/frontend/frontend/src/styles/Ordenes.css
+++ b/frontend/frontend/src/styles/Ordenes.css
@@ -12,13 +12,14 @@
   padding: 1rem;
 }
 
+
 .ordenes-sidebar .accordion-button {
-  background-color: #495057;
+  background-color: rgba(255, 255, 255, 0.15);
   color: #fff;
 }
 
-.ordenes-sidebar .accordion-button.collapsed {
-  background-color: #343a40;
+.ordenes-sidebar .accordion-button:not(.collapsed) {
+  background-color: rgba(255, 255, 255, 0.25);
 }
 
 .ordenes-sidebar .accordion-button:focus {
@@ -26,11 +27,11 @@
 }
 
 .ordenes-sidebar .list-group-item {
-  background-color: #343a40;
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 .ordenes-sidebar .list-group-item:hover {
-  background-color: #495057;
+  background-color: rgba(255, 255, 255, 0.15);
 }
 
 


### PR DESCRIPTION
## Summary
- better colors for accordions in `Ordenes` app
- show which section is active in `Dashboard` sidebar and add **Estadísticas** entry
- highlight active link in sidebar via CSS

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a9090a76c832ba2f465296d2837bb