### PR TITLE
Add statistics endpoint and update frontend

### DIFF
--- a/backend/lxhapp/routes/ordenes.js
+++ b/backend/lxhapp/routes/ordenes.js
@@ -211,6 +211,41 @@ router.get('/detalle', verificarToken, async (req, res) => {
 });
 router.get('/tree', projectController.getOrdenesTree);
 
+// Obtener estadísticas globales de órdenes
+router.get('/estadisticas', verificarToken, async (req, res) => {
+  try {
+    const [porUsuario] = await pool.query(
+      `SELECT u.nombre AS usuario, COUNT(*) AS total
+       FROM ordenes o
+       JOIN usuarios u ON o.usuario_id = u.id
+       GROUP BY o.usuario_id`
+    );
+
+    const [porMaterial] = await pool.query(
+      `SELECT material, COUNT(*) AS total
+       FROM ordenes
+       GROUP BY material`
+    );
+
+    const [pesoProyecto] = await pool.query(
+      `SELECT p.nombre_proyecto AS proyecto,
+              SUM(COALESCE(o.peso, 0)) AS total_peso
+       FROM ordenes o
+       JOIN proyectos p ON o.proyecto_id = p.id
+       GROUP BY o.proyecto_id`
+    );
+
+    res.json({
+      ordenesPorUsuario: porUsuario,
+      ordenesPorMaterial: porMaterial,
+      pesoTotalPorProyecto: pesoProyecto
+    });
+  } catch (error) {
+    console.error('Error obteniendo estadísticas:', error);
+    res.status(500).json({ mensaje: 'Error al obtener estadísticas' });
+  }
+});
+
 // Guardar imágenes para una orden
 router.post('/:id/imagenes', async (req, res) => {
   const { id } = req.params;

--- a/frontend/frontend/src/apps/Estadisticas.jsx
+++ b/frontend/frontend/src/apps/Estadisticas.jsx
@@ -4,61 +4,63 @@ import { Bar, Pie } from 'react-chartjs-2';
 import Chart from 'chart.js/auto';
 
 const Estadisticas = () => {
-  const [ordenes, setOrdenes] = useState([]);
+  const [stats, setStats] = useState({
+    ordenesPorUsuario: [],
+    ordenesPorMaterial: [],
+    pesoTotalPorProyecto: []
+  });
+
   const token = localStorage.getItem('token');
 
   useEffect(() => {
     if (!token) return;
     axios
-      .get('http://localhost:3000/ordenes', { headers: { Authorization: `Bearer ${token}` } })
-      .then((res) => setOrdenes(res.data))
+      .get('http://localhost:3000/ordenes/estadisticas', {
+        headers: { Authorization: `Bearer ${token}` }
+      })
+      .then((res) => setStats(res.data))
       .catch((err) => console.error('Error al cargar estadísticas:', err));
   }, [token]);
 
-  const totalOrdenes = ordenes.length;
-  const porMaterial = {};
-  const porResponsable = {};
-  ordenes.forEach((o) => {
-    if (o.material) {
-      porMaterial[o.material] = (porMaterial[o.material] || 0) + 1;
-    }
-    if (o.responsable) {
-      porResponsable[o.responsable] = (porResponsable[o.responsable] || 0) + 1;
-    }
-  });
-
-  const materiales = Object.keys(porMaterial);
-  const materialCounts = Object.values(porMaterial);
-
-  const responsables = Object.keys(porResponsable);
-  const responsableCounts = Object.values(porResponsable);
+  const totalOrdenes = stats.ordenesPorMaterial.reduce((sum, m) => sum + m.total, 0);
 
   const pieData = {
-    labels: materiales,
+    labels: stats.ordenesPorMaterial.map((m) => m.material || 'Sin material'),
     datasets: [
       {
-        data: materialCounts,
+        data: stats.ordenesPorMaterial.map((m) => m.total),
         backgroundColor: [
           '#007bff',
           '#28a745',
           '#dc3545',
           '#ffc107',
           '#17a2b8',
-          '#6610f2',
-        ],
-      },
-    ],
+          '#6610f2'
+        ]
+      }
+    ]
   };
 
-  const barData = {
-    labels: responsables,
+  const barUsuarioData = {
+    labels: stats.ordenesPorUsuario.map((u) => u.usuario),
     datasets: [
       {
-        label: 'Órdenes por responsable',
-        data: responsableCounts,
-        backgroundColor: '#007bff',
-      },
-    ],
+        label: 'Órdenes por usuario',
+        data: stats.ordenesPorUsuario.map((u) => u.total),
+        backgroundColor: '#007bff'
+      }
+    ]
+  };
+
+  const barPesoData = {
+    labels: stats.pesoTotalPorProyecto.map((p) => p.proyecto),
+    datasets: [
+      {
+        label: 'Peso total',
+        data: stats.pesoTotalPorProyecto.map((p) => p.total_peso),
+        backgroundColor: '#28a745'
+      }
+    ]
   };
 
   return (
@@ -66,13 +68,17 @@ const Estadisticas = () => {
       <h2 className="mb-4">Estadísticas de Órdenes Internas</h2>
       <p>Total de órdenes: {totalOrdenes}</p>
       <div className="row">
-        <div className="col-md-6 mb-4">
+        <div className="col-md-4 mb-4">
+          <h5 className="text-center">Órdenes por usuario</h5>
+          <Bar data={barUsuarioData} />
+        </div>
+        <div className="col-md-4 mb-4">
           <h5 className="text-center">Órdenes por material</h5>
           <Pie data={pieData} />
         </div>
-        <div className="col-md-6 mb-4">
-          <h5 className="text-center">Órdenes por responsable</h5>
-          <Bar data={barData} />
+        <div className="col-md-4 mb-4">
+          <h5 className="text-center">Peso total por proyecto</h5>
+          <Bar data={barPesoData} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add backend endpoint `/ordenes/estadisticas`
- show order statistics in dashboard

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a93184364832b8b4482bba5575902