### PR TITLE
Store OF images in DB and update upload flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ npm start
 
 El backend necesita un archivo `.env` con la configuración de la base de datos y la clave `JWT_SECRET`.
 
+## Tabla para almacenar imágenes
+
+Para guardar las imágenes asociadas a cada orden en la base de datos se utiliza la tabla `orden_imagenes`:
+
+```sql
+CREATE TABLE orden_imagenes (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  orden_id INT NOT NULL,
+  posicion INT NOT NULL,
+  imagen LONGBLOB NOT NULL,
+  FOREIGN KEY (orden_id) REFERENCES ordenes(id) ON DELETE CASCADE
+);
+```
+

--- a/backend/lxhapp/routes/ordenes.js
+++ b/backend/lxhapp/routes/ordenes.js
@@ -254,15 +254,13 @@ router.post('/:id/imagenes', async (req, res) => {
     return res.status(400).json({ mensaje: 'No se enviaron imágenes' });
   }
   try {
-    const dir = path.join(__dirname, '..', 'uploads', id.toString());
-    await fs.promises.mkdir(dir, { recursive: true });
     await Promise.all(
       imagenes.map((img, idx) => {
-        const match = img.match(/^data:image\/(\w+);base64,/);
-        const ext = match ? match[1] : 'png';
         const base64Data = img.replace(/^data:image\/\w+;base64,/, '');
-        const filePath = path.join(dir, `${idx}.${ext}`);
-        return fs.promises.writeFile(filePath, base64Data, 'base64');
+        return pool.query(
+          'INSERT INTO orden_imagenes (orden_id, posicion, imagen) VALUES (?, ?, ?)',
+          [id, idx, base64Data]
+        );
       })
     );
     res.json({ mensaje: 'Imágenes guardadas correctamente' });


### PR DESCRIPTION
## Summary
- persist uploaded images to new `orden_imagenes` table
- include DB schema instructions in README
- enable adding images when creating an order and choose number of images

## Testing
- `npm test` (fails: `Error: no test specified`)
- `npm test --silent` in frontend (fails: `react-scripts: not found`)


------
https://chatgpt.com/codex/tasks/task_e_684bd25cb2d0832ba580c902e4b6679a