### PR TITLE
Add general orders view

### DIFF
--- a/backend/lxhapp/routes/ordenes.js
+++ b/backend/lxhapp/routes/ordenes.js
@@ -209,6 +209,19 @@ router.get('/detalle', verificarToken, async (req, res) => {
         res.status(500).json({ mensaje: 'Error al obtener las órdenes completas', error });
     }
 });
+
+// Obtener todas las órdenes sin filtrar por usuario (vista general)
+router.get('/all', verificarToken, async (req, res) => {
+    try {
+        const [ordenes] = await pool.query(
+            `SELECT * FROM ordenes ORDER BY fecha_inicio DESC`
+        );
+        res.json(ordenes);
+    } catch (error) {
+        console.error("Error al obtener todas las órdenes:", error);
+        res.status(500).json({ mensaje: 'Error al obtener las órdenes' });
+    }
+});
 router.get('/tree', projectController.getOrdenesTree);
 
 // Obtener estadísticas globales de órdenes

--- a/backend/lxhapp/routes/ordenesExternas.js
+++ b/backend/lxhapp/routes/ordenesExternas.js
@@ -53,4 +53,17 @@ router.get('/', verificarToken, async (req, res) => {
   }
 });
 
+// Listar todas las órdenes externas sin filtrar por usuario
+router.get('/all', verificarToken, async (req, res) => {
+  try {
+    const [ordenes] = await pool.query(
+      'SELECT id, cliente, proyecto, figura, pdf_path, usuario_id FROM ordenes_externas ORDER BY id DESC'
+    );
+    res.json(ordenes);
+  } catch (error) {
+    console.error('Error listando ordenes externas:', error);
+    res.status(500).json({ mensaje: 'Error al obtener ordenes externas' });
+  }
+});
+
 module.exports = router;

--- a/frontend/frontend/src/apps/VerOFs.jsx
+++ b/frontend/frontend/src/apps/VerOFs.jsx
@@ -74,14 +74,14 @@ const VerOFs = () => {
   useEffect(() => {
     if (!token) return;
     axios
-      .get("http://localhost:3000/ordenes", {
+      .get("http://localhost:3000/ordenes/all", {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => setOrdenes(res.data))
       .catch((err) => console.error("Error obteniendo internas", err));
 
     axios
-      .get("http://localhost:3000/ordenes-externas", {
+      .get("http://localhost:3000/ordenes-externas/all", {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => setExternas(res.data))


### PR DESCRIPTION
## Summary
- add `/all` endpoint to show all internal orders
- add `/all` endpoint for external orders
- fetch all orders on the "Ver OFs" page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test --silent` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd22ba0f4832bbf69c37deec17527