### PR TITLE
Fix order filtering and show creator info

### DIFF
--- a/backend/lxhapp/controllers/project.controller.js
+++ b/backend/lxhapp/controllers/project.controller.js
@@ -2,21 +2,36 @@ const pool = require('../db'); // Asegúrate de tener el pool conectado a MySQL
 
 const getOrdenesTree = async (req, res) => {
   try {
-    const [clientes] = await pool.query('SELECT * FROM clientes');
+    const usuario_id = req.usuario.id;
 
-    const tree = await Promise.all(clientes.map(async (cliente) => {
-      const [proyectos] = await pool.query('SELECT * FROM proyectos WHERE cliente_id = ?', [cliente.id]);
+    const [clientes] = await pool.query(
+      'SELECT * FROM clientes WHERE usuario_id = ?',
+      [usuario_id]
+    );
 
-      const proyectosConOrdenes = await Promise.all(proyectos.map(async (proyecto) => {
-        const [ordenes] = await pool.query('SELECT * FROM ordenes WHERE proyecto_id = ?', [proyecto.id]);
-        return { proyecto, ordenes };
-      }));
+    const tree = await Promise.all(
+      clientes.map(async (cliente) => {
+        const [proyectos] = await pool.query(
+          'SELECT * FROM proyectos WHERE cliente_id = ? AND usuario_id = ?',
+          [cliente.id, usuario_id]
+        );
 
-      return {
-        cliente,
-        proyectos: proyectosConOrdenes
-      };
-    }));
+        const proyectosConOrdenes = await Promise.all(
+          proyectos.map(async (proyecto) => {
+            const [ordenes] = await pool.query(
+              'SELECT * FROM ordenes WHERE proyecto_id = ? AND usuario_id = ?',
+              [proyecto.id, usuario_id]
+            );
+            return { proyecto, ordenes };
+          })
+        );
+
+        return {
+          cliente,
+          proyectos: proyectosConOrdenes,
+        };
+      })
+    );
 
     res.json(tree);
   } catch (error) {

--- a/backend/lxhapp/routes/ordenes.js
+++ b/backend/lxhapp/routes/ordenes.js
@@ -214,7 +214,10 @@ router.get('/detalle', verificarToken, async (req, res) => {
 router.get('/all', verificarToken, async (req, res) => {
     try {
         const [ordenes] = await pool.query(
-            `SELECT * FROM ordenes ORDER BY fecha_inicio DESC`
+            `SELECT o.*, u.nombre AS creador
+             FROM ordenes o
+             JOIN usuarios u ON o.usuario_id = u.id
+             ORDER BY o.fecha_inicio DESC`
         );
         res.json(ordenes);
     } catch (error) {
@@ -222,7 +225,7 @@ router.get('/all', verificarToken, async (req, res) => {
         res.status(500).json({ mensaje: 'Error al obtener las órdenes' });
     }
 });
-router.get('/tree', projectController.getOrdenesTree);
+router.get('/tree', verificarToken, projectController.getOrdenesTree);
 
 // Obtener estadísticas globales de órdenes
 router.get('/estadisticas', verificarToken, async (req, res) => {

--- a/backend/lxhapp/routes/ordenesExternas.js
+++ b/backend/lxhapp/routes/ordenesExternas.js
@@ -57,7 +57,10 @@ router.get('/', verificarToken, async (req, res) => {
 router.get('/all', verificarToken, async (req, res) => {
   try {
     const [ordenes] = await pool.query(
-      'SELECT id, cliente, proyecto, figura, pdf_path, usuario_id FROM ordenes_externas ORDER BY id DESC'
+      `SELECT oe.id, oe.cliente, oe.proyecto, oe.figura, oe.pdf_path, oe.usuario_id, u.nombre AS creador
+       FROM ordenes_externas oe
+       JOIN usuarios u ON oe.usuario_id = u.id
+       ORDER BY oe.id DESC`
     );
     res.json(ordenes);
   } catch (error) {

--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -130,7 +130,9 @@ const Ordenes = () => {
 
   const fetchOrdenesTree = () => {
     return axios
-      .get("http://localhost:3000/ordenes/tree")
+      .get("http://localhost:3000/ordenes/tree", {
+        headers: { Authorization: `Bearer ${token}` },
+      })
       .then((res) => {
         setOrdenesTree(res.data);
         return res.data;

--- a/frontend/frontend/src/apps/VerOFs.jsx
+++ b/frontend/frontend/src/apps/VerOFs.jsx
@@ -345,7 +345,7 @@ const VerOFs = () => {
                       <td>{o.figura}</td>
                       <td>{o.nombre_proyecto}</td>
                       <td>{o.nombre_cliente}</td>
-                      <td>{localStorage.getItem("username")}</td>
+                      <td>{o.creador}</td>
                       <td>
                         <span className={getStatusClass(status)}>
                           {getStatusIcon(status)}
@@ -462,7 +462,7 @@ const VerOFs = () => {
                         <td>{o.figura}</td>
                         <td>{o.proyecto}</td>
                         <td>{o.cliente}</td>
-                        <td>{localStorage.getItem("username")}</td>
+                        <td>{o.creador}</td>
                         <td>-</td>
                         <td>
                           {o.fecha_creacion
@@ -598,7 +598,7 @@ const VerOFs = () => {
                 {new Date(seleccionada.fecha_creacion).toLocaleString()}
               </p>
               <p>
-                <strong>Creada por:</strong> {localStorage.getItem("username")}
+                <strong>Creada por:</strong> {seleccionada.creador}
               </p>
             </div>
           )}


### PR DESCRIPTION
## Summary
- filter the orders tree by `usuario_id`
- secure the tree route and include creator name for orders
- include creator name when listing external orders
- send auth token when fetching the order tree
- show the creator field when viewing orders

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend (prints "Error: no test specified")

------
https://chatgpt.com/codex/tasks/task_e_684fd8220020832bac6d45a5107b1f4a