### PR TITLE
Use new 'imagenes' table

### DIFF
--- a/backend/lxhapp/controllers/project.controller.js
+++ b/backend/lxhapp/controllers/project.controller.js
@@ -22,6 +22,16 @@ const getOrdenesTree = async (req, res) => {
               'SELECT * FROM ordenes WHERE proyecto_id = ? AND usuario_id = ?',
               [proyecto.id, usuario_id]
             );
+
+            for (const orden of ordenes) {
+              const [imgs] = await pool.query(
+                'SELECT ruta FROM imagenes WHERE orden_id = ? ORDER BY posicion',
+                [orden.id]
+              );
+              const rutas = imgs.map((img) => img.ruta);
+              orden.imagenes = JSON.stringify({ layout: rutas.length, rutas });
+            }
+
             return { proyecto, ordenes };
           })
         );


### PR DESCRIPTION
## Summary
- insert orders without `imagenes` column
- return image info from the new `imagenes` table
- fetch images from the new table in PDF generation
- store uploaded images in the `imagenes` table

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684fe6e3fd30832b889514cacbbf3b9e