### PR TITLE
Fix saved image preview for orders

### DIFF
--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -134,8 +134,36 @@ const Ordenes = () => {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => {
-        setOrdenesTree(res.data);
-        return res.data;
+        const parsed = res.data.map((cliente) => ({
+          ...cliente,
+          proyectos: cliente.proyectos.map((proyecto) => ({
+            ...proyecto,
+            ordenes: proyecto.ordenes.map((orden) => {
+              let imgs = [];
+              if (orden.imagenes) {
+                try {
+                  const info =
+                    typeof orden.imagenes === "string"
+                      ? JSON.parse(orden.imagenes)
+                      : orden.imagenes;
+                  if (Array.isArray(info)) {
+                    imgs = info;
+                  } else if (info && Array.isArray(info.rutas)) {
+                    imgs = info.rutas.map((ruta, idx) => ({
+                      posicion: idx + 1,
+                      ruta,
+                    }));
+                  }
+                } catch (e) {
+                  console.error("Error parsing imagenes", e);
+                }
+              }
+              return { ...orden, imagenes: imgs };
+            }),
+          })),
+        }));
+        setOrdenesTree(parsed);
+        return parsed;
       })
       .catch((err) => {
         console.error("Error al cargar árbol:", err);
@@ -368,18 +396,27 @@ const Ordenes = () => {
     setErrorImagenes(null);
     try {
       const data = new FormData();
+      const existing = [];
       imagenesModal.forEach((img, idx) => {
         if (img?.file) {
-          data.append('imagenes', img.file);
-          data.append('posiciones', idx + 1);
+          data.append("imagenes", img.file);
+          existing.push("");
+        } else {
+          const prev = ordenSeleccionada.imagenes?.find(
+            (i) => i.posicion === idx + 1
+          );
+          existing.push(prev ? prev.ruta : "");
         }
       });
+      data.append("existing", JSON.stringify(existing));
+      data.append("layout", imagenesModal.length);
       const res = await axios.post(
         `http://localhost:3000/ordenes/${ordenSeleccionada.id}/imagenes`,
         data,
         { headers: { Authorization: `Bearer ${token}` } }
       );
-      const nuevas = res.data.imagenes || [];
+      const rutas = res.data.rutas || [];
+      const nuevas = rutas.map((ruta, idx) => ({ posicion: idx + 1, ruta }));
       const arr = Array(5).fill(null);
       nuevas.forEach((img) => {
         if (img.posicion >= 1 && img.posicion <= 5) {
@@ -391,10 +428,10 @@ const Ordenes = () => {
       });
       setImagenesModal(arr);
       setOrdenSeleccionada({ ...ordenSeleccionada, imagenes: nuevas });
-      mostrarModalTemporal('Imágenes guardadas correctamente');
+      mostrarModalTemporal("Imágenes guardadas correctamente");
     } catch (err) {
-      console.error('Error guardando imágenes', err);
-      setErrorImagenes('Error al guardar imágenes');
+      console.error("Error guardando imágenes", err);
+      setErrorImagenes("Error al guardar imágenes");
     } finally {
       setCargandoImagenes(false);
       setShowModal(false);
@@ -498,11 +535,27 @@ const Ordenes = () => {
                       .toISOString()
                       .slice(0, 10);
                   }
-                  setOrdenSeleccionada(orden);
+                  let imagenesData = orden.imagenes;
+                  if (typeof imagenesData === "string") {
+                    try {
+                      const parsed = JSON.parse(imagenesData);
+                      if (parsed && Array.isArray(parsed.rutas)) {
+                        imagenesData = parsed.rutas.map((ruta, idx) => ({
+                          posicion: idx + 1,
+                          ruta,
+                        }));
+                      } else {
+                        imagenesData = [];
+                      }
+                    } catch (_) {
+                      imagenesData = [];
+                    }
+                  }
+                  setOrdenSeleccionada({ ...orden, imagenes: imagenesData });
                   setForm(editableCopy);
-                  if (orden.imagenes && Array.isArray(orden.imagenes)) {
+                  if (Array.isArray(imagenesData) && imagenesData.length > 0) {
                     const imgs = Array(5).fill(null);
-                    orden.imagenes.forEach((img) => {
+                    imagenesData.forEach((img) => {
                       if (img.posicion >= 1 && img.posicion <= 5) {
                         imgs[img.posicion - 1] = {
                           file: null,


### PR DESCRIPTION
## Summary
- ensure `fetchOrdenesTree` parses the images field so existing images load correctly
- adapt save image handler to read `rutas` from backend
- parse image strings when selecting an order so placeholders show stored images
- preserve previously uploaded images when adding new ones

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685114804e40832bbe2600da4f2177d1