### PR TITLE
Resolve duplicate /ordenes route

### DIFF
--- a/backend/lxhapp/routes/ordenes.js
+++ b/backend/lxhapp/routes/ordenes.js
@@ -171,31 +171,8 @@ router.delete('/:id', verificarToken, async (req, res) => {
 });
 
 
-// Obtener todas las órdenes del usuario autenticado
-router.get('/', verificarToken, async (req, res) => {
-    const usuario_id = req.usuario.id;
-
-    try {
-        const [ordenes] = await pool.query('SELECT * FROM ordenes WHERE usuario_id = ?', [usuario_id]);
-
-        for (const orden of ordenes) {
-            const [imgs] = await pool.query(
-                'SELECT ruta FROM imagenes WHERE orden_id = ? ORDER BY posicion',
-                [orden.id]
-            );
-            const rutas = imgs.map(img => img.ruta);
-            orden.imagenes = JSON.stringify({ layout: rutas.length, rutas });
-        }
-
-        res.json(ordenes);
-    } catch (error) {
-        console.error(error);
-        res.status(500).json({ mensaje: 'Error al obtener las órdenes', error });
-    }
-});
-
 // Obtener una lista simplificada de órdenes (para mostrar en el listado)
-router.get('/', verificarToken, async (req, res) => {
+router.get('/resumen', verificarToken, async (req, res) => {
     const usuario_id = req.usuario.id;
 
     try {

--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -121,7 +121,7 @@ const Ordenes = () => {
       return;
     }
     axios
-      .get("http://localhost:3000/ordenes", { headers: { Authorization: `Bearer ${token}` } })
+      .get("http://localhost:3000/ordenes/detalle", { headers: { Authorization: `Bearer ${token}` } })
       .then((res) => setOrdenes(res.data))
       .catch((error) => console.error(error));
   }, [token, navigate]);


### PR DESCRIPTION
## Summary
- remove the duplicated `router.get('/')` route
- create `/resumen` endpoint
- adjust frontend to call `/ordenes/detalle`

## Testing
- `CI=true npm test --prefix frontend/frontend` *(fails: react-scripts not found)*
- `npm test --prefix backend/lxhapp`

------
https://chatgpt.com/codex/tasks/task_e_68511f2042d0832ba109cc9a20c0c33d