### PR TITLE
Add configurable API URL in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ npm start
 
 El backend necesita un archivo `.env` con la configuración de la base de datos y la clave `JWT_SECRET`.
 
+Para el frontend, copia `.env.example` como `.env` y ajusta `REACT_APP_API_URL` si la API se encuentra en otra dirección.
+

--- a/frontend/frontend/.env.example
+++ b/frontend/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:3000

--- a/frontend/frontend/src/apps/Estadisticas.jsx
+++ b/frontend/frontend/src/apps/Estadisticas.jsx
@@ -16,7 +16,7 @@ const Estadisticas = () => {
   useEffect(() => {
     if (!token) return;
     axios
-      .get('http://localhost:3000/ordenes/estadisticas', {
+      .get(`${process.env.REACT_APP_API_URL}/ordenes/estadisticas`, {
         headers: { Authorization: `Bearer ${token}` }
       })
       .then((res) => setStats(res.data))

--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -7,6 +7,8 @@ import { useDropzone } from "react-dropzone";
 import "../styles/Ordenes.css";
 import { FolderOpen, User, Folder, FileText } from "lucide-react";
 
+const API_URL = process.env.REACT_APP_API_URL;
+
 
 
 
@@ -121,7 +123,7 @@ const Ordenes = () => {
       return;
     }
     axios
-      .get("http://localhost:3000/ordenes", { headers: { Authorization: `Bearer ${token}` } })
+      .get(`${API_URL}/ordenes`, { headers: { Authorization: `Bearer ${token}` } })
       .then((res) => setOrdenes(res.data))
       .catch((error) => console.error(error));
   }, [token, navigate]);
@@ -130,7 +132,7 @@ const Ordenes = () => {
 
   const fetchOrdenesTree = useCallback(() => {
     return axios
-      .get("http://localhost:3000/ordenes/tree", {
+      .get(`${API_URL}/ordenes/tree`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => {
@@ -190,7 +192,7 @@ const Ordenes = () => {
   const handlePreviewPDF = useCallback(async (id) => {
     if (!id || !token) return;
     try {
-      const response = await fetch(`http://localhost:3000/ordenes/${id}/pdf`, {
+      const response = await fetch(`${API_URL}/ordenes/${id}/pdf`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -274,13 +276,13 @@ const Ordenes = () => {
     e.preventDefault();
     try {
       if (ordenSeleccionada) {
-        await axios.put(`http://localhost:3000/ordenes/${ordenSeleccionada.id}`, form, {
+        await axios.put(`${API_URL}/ordenes/${ordenSeleccionada.id}`, form, {
           headers: { Authorization: `Bearer ${token}` },
         });
         mostrarModalTemporal("Orden actualizada con éxito");
         setOrdenSeleccionada({ ...ordenSeleccionada, ...form });
       } else {
-        const { data } = await axios.post("http://localhost:3000/ordenes", form, {
+        const { data } = await axios.post(`${API_URL}/ordenes`, form, {
           headers: { Authorization: `Bearer ${token}` },
         });
         mostrarModalTemporal("Orden creada con éxito");
@@ -305,7 +307,7 @@ const Ordenes = () => {
     if (!confirmacion) return;
     
   try {
-      await axios.delete(`http://localhost:3000/ordenes/${ordenSeleccionada.id}`, {
+      await axios.delete(`${API_URL}/ordenes/${ordenSeleccionada.id}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       alert("Orden eliminada con éxito");
@@ -358,7 +360,7 @@ const Ordenes = () => {
       return;
     }
 
-    const url = `http://localhost:3000/ordenes/${id}/pdf${cliente ? "?cliente=true" : ""}`;
+    const url = `${API_URL}/ordenes/${id}/pdf${cliente ? "?cliente=true" : ""}`;
 
     try {
       setLoadingPDF(true);
@@ -411,7 +413,7 @@ const Ordenes = () => {
       data.append("existing", JSON.stringify(existing));
       data.append("layout", imagenesModal.length);
       const res = await axios.post(
-        `http://localhost:3000/ordenes/${ordenSeleccionada.id}/imagenes`,
+        `${API_URL}/ordenes/${ordenSeleccionada.id}/imagenes`,
         data,
         { headers: { Authorization: `Bearer ${token}` } }
       );
@@ -422,7 +424,7 @@ const Ordenes = () => {
         if (img.posicion >= 1 && img.posicion <= 5) {
           arr[img.posicion - 1] = {
             file: null,
-            preview: `http://localhost:3000${img.ruta}`,
+            preview: `${API_URL}${img.ruta}`,
           };
         }
       });
@@ -559,7 +561,7 @@ const Ordenes = () => {
                       if (img.posicion >= 1 && img.posicion <= 5) {
                         imgs[img.posicion - 1] = {
                           file: null,
-                          preview: `http://localhost:3000${img.ruta}`,
+                          preview: `${API_URL}${img.ruta}`,
                         };
                       }
                     });

--- a/frontend/frontend/src/apps/OrdenesExternas.jsx
+++ b/frontend/frontend/src/apps/OrdenesExternas.jsx
@@ -27,7 +27,7 @@ const OrdenesExternas = () => {
     data.append('figura', form.figura);
 
     try {
-      await axios.post('http://localhost:3000/ordenes-externas', data, {
+      await axios.post(`${process.env.REACT_APP_API_URL}/ordenes-externas`, data, {
         headers: { Authorization: `Bearer ${token}` },
       });
       alert('Orden externa guardada');

--- a/frontend/frontend/src/apps/VerOFs.jsx
+++ b/frontend/frontend/src/apps/VerOFs.jsx
@@ -74,14 +74,14 @@ const VerOFs = () => {
   useEffect(() => {
     if (!token) return;
     axios
-      .get("http://localhost:3000/ordenes/all", {
+      .get(`${process.env.REACT_APP_API_URL}/ordenes/all`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => setOrdenes(res.data))
       .catch((err) => console.error("Error obteniendo internas", err));
 
     axios
-      .get("http://localhost:3000/ordenes-externas/all", {
+      .get(`${process.env.REACT_APP_API_URL}/ordenes-externas/all`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => setExternas(res.data))
@@ -240,7 +240,7 @@ const VerOFs = () => {
     if (!id || !token) return;
     try {
       setLoadingPDF(true);
-      const response = await fetch(`http://localhost:3000/ordenes/${id}/pdf`, {
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/ordenes/${id}/pdf`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -488,7 +488,7 @@ const VerOFs = () => {
                         </td>
                         <td>
                           <a
-                            href={`http://localhost:3000${o.pdf_path}`}
+                            href={`${process.env.REACT_APP_API_URL}${o.pdf_path}`}
                             target="_blank"
                             rel="noreferrer"
                             className="btn btn-sm btn-outline-primary"

--- a/frontend/frontend/src/components/Login.js
+++ b/frontend/frontend/src/components/Login.js
@@ -18,7 +18,10 @@ const Login = () => {
     e.preventDefault();
     setError("");
     try {
-      const response = await axios.post("http://localhost:3000/login", form);
+      const response = await axios.post(
+        `${process.env.REACT_APP_API_URL}/login`,
+        form
+      );
       localStorage.setItem("token", response.data.token);
       localStorage.setItem("rol", response.data.rol);
       localStorage.setItem("username", response.data.nombre);

--- a/frontend/frontend/src/components/Register.js
+++ b/frontend/frontend/src/components/Register.js
@@ -37,7 +37,10 @@ const Register = () => {
     }
 
     try {
-      await axios.post("http://localhost:3000/register", form);
+      await axios.post(
+        `${process.env.REACT_APP_API_URL}/register`,
+        form
+      );
       alert("Usuario registrado con éxito");
       navigate("/login");
     } catch (error) {

--- a/frontend/frontend/src/pages/Dashboard.jsx
+++ b/frontend/frontend/src/pages/Dashboard.jsx
@@ -10,6 +10,8 @@ import Estadisticas from "../apps/Estadisticas";
 import { Modal, Button } from "react-bootstrap";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
+const API_URL = process.env.REACT_APP_API_URL;
+
 const Dashboard = () => {
   const navigate = useNavigate();
   const [mensaje, setMensaje] = useState("");
@@ -32,7 +34,7 @@ const Dashboard = () => {
     }
 
     axios
-      .get(`http://localhost:3000/usuarios/${nombreUsuario}`, {
+      .get(`${API_URL}/usuarios/${nombreUsuario}`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((response) => {
@@ -75,10 +77,10 @@ const Dashboard = () => {
     e.preventDefault();
     const token = localStorage.getItem("token");
     try {
-      await axios.put(`http://localhost:3000/usuarios/${perfil.nombre}`, editData, {
+      await axios.put(`${API_URL}/usuarios/${perfil.nombre}`, editData, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      const res = await axios.get(`http://localhost:3000/usuarios/${editData.nombre}`, {
+      const res = await axios.get(`${API_URL}/usuarios/${editData.nombre}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       setPerfil(res.data);
@@ -191,7 +193,9 @@ const Dashboard = () => {
           </div>
           <div className="dropdown" ref={dropdownRef}>
             <img
-              src={perfil?.avatar ? `http://localhost:3000${perfil.avatar}` : "/silueta.jpg"}
+              src={
+                perfil?.avatar ? `${API_URL}${perfil.avatar}` : "/silueta.jpg"
+              }
               alt=""
               className="perfil-img dropdown-toggle"
               onClick={() => setMenuAbierto(!menuAbierto)}
@@ -225,7 +229,7 @@ const Dashboard = () => {
           {perfil && (
             <>
               <img
-                src={perfil.avatar ? `http://localhost:3000${perfil.avatar}` : "/silueta.jpg"}
+                src={perfil.avatar ? `${API_URL}${perfil.avatar}` : "/silueta.jpg"}
                 alt="avatar"
                 className="rounded-circle mb-3"
                 style={{ width: "100px", height: "100px", objectFit: "cover" }}


### PR DESCRIPTION
## Summary
- add `.env.example` with `REACT_APP_API_URL`
- use `process.env.REACT_APP_API_URL` throughout frontend code
- document new env variable in README

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511f2b0ecc832b9762b72ee42f3975