### PR TITLE
Fix deletion and missing image errors

### DIFF
--- a/backend/lxhapp/routes/pdf.js
+++ b/backend/lxhapp/routes/pdf.js
@@ -53,19 +53,23 @@ router.post("/:id/pdf", async (req, res) => {
         [id]
       );
       const rutas = imgs.map((img) => img.ruta);
-      layoutSeleccionado = rutas.length;
-      imagenes = await Promise.all(
+      const archivos = await Promise.all(
         rutas.map(async (ruta) => {
           const abs = path.join(
             __dirname,
             '..',
             ruta.replace('/ordenes-img/', 'uploads/ordenes/')
           );
-          const data = await fs.promises.readFile(abs);
+          const data = await fs.promises
+            .readFile(abs)
+            .catch(() => null);
+          if (!data) return null;
           const ext = path.extname(ruta).substring(1);
           return `data:image/${ext};base64,${data.toString('base64')}`;
         })
       );
+      imagenes = archivos.filter(Boolean);
+      layoutSeleccionado = imagenes.length;
     } catch (e) {
       console.error('Error leyendo imágenes', e);
     }


### PR DESCRIPTION
## Summary
- remove images and folders before deleting an order
- gracefully ignore missing image files when generating PDFs

## Testing
- `npm --prefix backend/lxhapp test`

------
https://chatgpt.com/codex/tasks/task_e_68527cf8a790832b9355be6c11422b67