### PR TITLE
Fix placeholder count in order insertion

### DIFF
--- a/backend/lxhapp/routes/ordenes.js
+++ b/backend/lxhapp/routes/ordenes.js
@@ -82,7 +82,7 @@ router.post('/', verificarToken, async (req, res) => {
           fabric_pieza, post_mec, pegar_lijar, esculpir,
           line_x, fibra, mortero, aparejo, pintura, estructura,
           peso, notas, cliente_id, proyecto_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         [
           usuario_id, nombre_cliente, nombre_proyecto, codigo_proyecto, responsable, figura,
           medida_v, medida_w, medida_h, unidad_medida,


### PR DESCRIPTION
## Summary
- fix mismatch between column and value counts when creating orders

## Testing
- `npm test --silent` (fails: Error: no test specified)
- `npm test --silent` in frontend (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_68527e44ab44832bb21faf3675cc5a5a