### PR TITLE
Fix SQL insert query formatting

### DIFF
--- a/backend/lxhapp/routes/ordenes.js
+++ b/backend/lxhapp/routes/ordenes.js
@@ -82,7 +82,7 @@ router.post('/', verificarToken, async (req, res) => {
           fabric_pieza, post_mec, pegar_lijar, esculpir,
           line_x, fibra, mortero, aparejo, pintura, estructura,
           peso, notas, cliente_id, proyecto_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           usuario_id, nombre_cliente, nombre_proyecto, codigo_proyecto, responsable, figura,
           medida_v, medida_w, medida_h, unidad_medida,


### PR DESCRIPTION
## Summary
- fix incorrectly formatted `INSERT INTO ordenes` statement

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68527f8913ec832ba188f2686cb575d2