### PR TITLE
Update Puppeteer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,9 @@ Copia `backend/lxhapp/.env.example` a `backend/lxhapp/.env` y completa los valor
 - `DB_PASSWORD`
 - `DB_NAME`
 - `JWT_SECRET`
+- `CHROME_PATH` (opcional, ruta al ejecutable de Chrome/Chromium para Puppeteer)
+
+Si tu sistema no utiliza la ruta predeterminada, asigna `CHROME_PATH` con la ruta
+al ejecutable de Chrome o Chromium para que Puppeteer lo utilice al generar los
+PDF.
 

--- a/backend/lxhapp/routes/pdf.js
+++ b/backend/lxhapp/routes/pdf.js
@@ -152,7 +152,7 @@ router.post("/:id/pdf", async (req, res) => {
 
     // **Iniciar Puppeteer**
     const browser = await puppeteer.launch({
-      executablePath: "/usr/bin/chromium-browser",
+      executablePath: process.env.CHROME_PATH || puppeteer.executablePath(),
       headless: true,
       args: ["--no-sandbox", "--disable-setuid-sandbox"],
     });


### PR DESCRIPTION
## Summary
- configure Puppeteer with `process.env.CHROME_PATH` or fallback `puppeteer.executablePath()`
- document the optional `CHROME_PATH` variable in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852868c0a00832b86ea9755c64a4944