### PR TITLE
Enable real-time chat

### DIFF
--- a/backend/lxhapp/package.json
+++ b/backend/lxhapp/package.json
@@ -24,5 +24,7 @@
     "pdf-lib": "^1.17.1",
     "puppeteer": "^19.0.0",
     "react-filepond": "^7.1.3"
+    ,
+    "socket.io": "^4.7.5"
   }
 }

--- a/backend/lxhapp/server.js
+++ b/backend/lxhapp/server.js
@@ -5,6 +5,8 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const cors = require('cors');
 const path = require('path');
+const http = require('http');
+const { Server } = require('socket.io');
 const userRoutes = require('./routes/userRoutes');
 const ordenesRoutes = require('./routes/ordenes');
 const pdfRoutes = require("./routes/pdf"); // PDF
@@ -13,6 +15,12 @@ const bodyParser = require("body-parser");
 const { verificarToken, verificarRol } = require('./middlewares/auth');
 
 const app = express();
+const httpServer = http.createServer(app);
+const io = new Server(httpServer, {
+    cors: {
+        origin: '*'
+    }
+});
 
 // 📌 **Aumentar el límite de `body-parser` para permitir imágenes en Base64**
 app.use(bodyParser.json({ limit: "50mb" }));
@@ -30,6 +38,45 @@ app.use('/ordenes', ordenesRoutes);
 app.use('/ordenes', pdfRoutes); // PDF
 app.use('/ordenes-externas', ordenesExternasRoutes);
 app.use('/externas', express.static(path.join(__dirname, 'uploads', 'externas')));
+
+// Devuelve historial de mensajes
+app.get('/mensajes', verificarToken, async (req, res) => {
+    try {
+        const [rows] = await pool.query(
+            'SELECT m.mensaje, u.email as user FROM mensajes m JOIN usuarios u ON m.usuario_id = u.id ORDER BY m.id ASC'
+        );
+        res.json(rows);
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ mensaje: 'Error al cargar mensajes' });
+    }
+});
+
+// Socket.io auth con JWT
+io.use((socket, next) => {
+    const token = socket.handshake.auth.token;
+    if (!token) return next(new Error('Authentication error'));
+    try {
+        const payload = jwt.verify(token, process.env.JWT_SECRET);
+        socket.user = payload;
+        next();
+    } catch (err) {
+        next(new Error('Authentication error'));
+    }
+});
+
+io.on('connection', (socket) => {
+    console.log(`Socket conectado: ${socket.user.email}`);
+    socket.on('chat message', async (msg) => {
+        const data = { user: socket.user.email, mensaje: msg };
+        io.emit('chat message', data);
+        try {
+            await pool.query('INSERT INTO mensajes (usuario_id, mensaje) VALUES (?, ?)', [socket.user.id, msg]);
+        } catch (err) {
+            console.error('Error guardando mensaje:', err);
+        }
+    });
+});
 
 // ✅ REGISTRO DE USUARIOS
 app.post('/register', async (req, res) => {
@@ -92,7 +139,7 @@ app.get('/admin', verificarToken, verificarRol(['admin']), (req, res) => {
 
 // ✅ **Servidor en ejecución**
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
+httpServer.listen(PORT, () => {
     console.log('✅ Hola LXH, el backend funciona correctamente');
     console.log(`🚀 Servidor corriendo en http://localhost:${PORT}`);
 });

--- a/frontend/frontend/package.json
+++ b/frontend/frontend/package.json
@@ -23,6 +23,7 @@
     "react-chartjs-2": "^5.2.0",
     "chart.js": "^4.4.1",
     "react-router-dom": "^7.3.0",
+    "socket.io-client": "^4.7.5",
     "react-scripts": "5.0.1",
     "source-map-loader": "^5.0.0",
     "web-vitals": "^2.1.4"

--- a/frontend/frontend/src/App.js
+++ b/frontend/frontend/src/App.js
@@ -3,7 +3,8 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 import Login from "./components/Login";
 import Register from "./components/Register";
 import Dashboard from "./pages/Dashboard";
-import Ordenes from './apps/Ordenes'; 
+import Ordenes from './apps/Ordenes';
+import Chat from './components/Chat';
 
 function App() {
   return (
@@ -14,7 +15,8 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
         <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/ordenes" element={<Ordenes />} /> 
+        <Route path="/ordenes" element={<Ordenes />} />
+        <Route path="/chat" element={<Chat />} />
       </Routes>
     </Router>
   );

--- a/frontend/frontend/src/components/Chat.jsx
+++ b/frontend/frontend/src/components/Chat.jsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+import axios from 'axios';
+
+const Chat = () => {
+  const [socket, setSocket] = useState(null);
+  const [message, setMessage] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) return;
+
+    axios
+      .get('http://localhost:3000/mensajes', {
+        headers: { Authorization: `Bearer ${token}` }
+      })
+      .then(res => setMessages(res.data))
+      .catch(err => console.error(err));
+
+    const newSocket = io('http://localhost:3000', {
+      auth: { token }
+    });
+    setSocket(newSocket);
+
+    newSocket.on('chat message', (msg) => {
+      setMessages((prev) => [...prev, msg]);
+    });
+
+    return () => newSocket.disconnect();
+  }, []);
+
+  const sendMessage = (e) => {
+    e.preventDefault();
+    if (message.trim() && socket) {
+      socket.emit('chat message', message);
+      setMessage('');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Chat</h2>
+      <ul>
+        {messages.map((m, i) => (
+          <li key={i}><b>{m.user}:</b> {m.mensaje}</li>
+        ))}
+      </ul>
+      <form onSubmit={sendMessage}>
+        <input
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Escribe un mensaje"
+        />
+        <button type="submit">Enviar</button>
+      </form>
+    </div>
+  );
+};
+
+export default Chat;


### PR DESCRIPTION
## Summary
- add socket.io to backend and socket.io-client to frontend
- start Socket.io server with JWT authentication
- create chat history endpoint and broadcast messages
- add React chat component and new `/chat` route

## Testing
- `npm test` in `backend/lxhapp` *(fails: no test specified)*
- `npm test --silent` in `frontend/frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685286ee305c832ba5a97a4c536bce2d