### PR TITLE
Add private user chat

### DIFF
--- a/backend/lxhapp/routes/userRoutes.js
+++ b/backend/lxhapp/routes/userRoutes.js
@@ -7,6 +7,17 @@ const path = require('path');
 const router = express.Router();
 const projectController = require('../controllers/project.controller');
 
+// Lista de usuarios (excepto el propio) para iniciar conversaciones
+router.get('/list', verificarToken, async (req, res) => {
+    try {
+        const [rows] = await pool.query('SELECT id, nombre FROM usuarios WHERE id <> ?', [req.usuario.id]);
+        res.json(rows);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ mensaje: 'Error al obtener usuarios' });
+    }
+});
+
 // Ruta dinámica basada en el nombre de usuario
 router.get('/:username', verificarToken, async (req, res) => {
     const { username } = req.params;  // Obtener el nombre de usuario desde la URL

--- a/frontend/frontend/src/pages/Dashboard.jsx
+++ b/frontend/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import axios from "axios";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "../styles/Dashboard.css";
@@ -174,6 +174,19 @@ const Dashboard = () => {
       >
         Ver OF's
       </button>
+    </li>
+    <li className="nav-item">
+      <Link
+        to="/chat"
+        className="nav-link text-white btn btn-link w-100 text-center p-2"
+        style={{ transition: 'background-color 0.3s, transform 0.2s' }}
+        onMouseEnter={(e) => e.target.style.backgroundColor = '#575757'}
+        onMouseLeave={(e) => e.target.style.backgroundColor = 'transparent'}
+        onMouseDown={(e) => e.target.style.transform = 'scale(0.98)'}
+        onMouseUp={(e) => e.target.style.transform = 'scale(1)'}
+      >
+        Chat
+      </Link>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
## Summary
- list registered users from `/usuarios/list`
- implement private conversations with new endpoints
- store/emit private socket messages
- allow chat selection and sending in React
- link chat from dashboard

## Testing
- `npm test` in frontend *(failed: react-scripts not found)*
- `npm test` in backend *(prints "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6852be077508832b89ff8a3965c4e7e1