### PR TITLE
Fix chat form submit handler

### DIFF
--- a/frontend/frontend/src/components/ChatWidget.jsx
+++ b/frontend/frontend/src/components/ChatWidget.jsx
@@ -138,13 +138,7 @@ const ChatWidget = () => {
               </div>
             ))}
           </div>
-          <form
-            onSubmit={e => {
-              e.preventDefault();
-              handleSend();
-            }}
-            className="flex p-2 border-t"
-          >
+          <form onSubmit={handleSend} className="flex p-2 border-t">
             <input
               className="flex-1 border rounded-l-full px-3 py-1 text-sm focus:outline-none"
               value={message}


### PR DESCRIPTION
## Summary
- ensure `handleSend` receives the submit event in `ChatWidget`

## Testing
- `npm test --silent` *(fails: `react-scripts: not found`)*
- `npm test --silent` in backend

------
https://chatgpt.com/codex/tasks/task_e_6852d73e1fc4832b902d57261b006147