### PR TITLE
Add hover style for user list items

### DIFF
--- a/frontend/frontend/src/styles/ChatWidget.css
+++ b/frontend/frontend/src/styles/ChatWidget.css
@@ -24,3 +24,8 @@
   background-color: #f1f1f1;
   color: #333;
 }
+
+.hover-bg-light:hover {
+  background-color: #f8f9fa;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add `.hover-bg-light` rule to ChatWidget CSS for hover highlighting

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852de8773fc832ba683a9920455cb0b