### PR TITLE
Add API_URL config for production

### DIFF
--- a/frontend/frontend/.env.example
+++ b/frontend/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:3000

--- a/frontend/frontend/src/api.js
+++ b/frontend/frontend/src/api.js
@@ -1,0 +1,2 @@
+export const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3000';
+export default API_URL;

--- a/frontend/frontend/src/apps/Estadisticas.jsx
+++ b/frontend/frontend/src/apps/Estadisticas.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import { API_URL } from '../api';
 import { Bar, Pie, Line } from 'react-chartjs-2';
 import Chart from 'chart.js/auto';
 
@@ -16,7 +17,7 @@ const Estadisticas = () => {
   useEffect(() => {
     if (!token) return;
     axios
-      .get('http://localhost:3000/ordenes/estadisticas', {
+      .get(`${API_URL}/ordenes/estadisticas`, {
         headers: { Authorization: `Bearer ${token}` }
       })
       .then((res) => setStats(res.data))

--- a/frontend/frontend/src/apps/Ordenes.jsx
+++ b/frontend/frontend/src/apps/Ordenes.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from "react";
 import axios from "axios";
+import { API_URL } from "../api";
 import Collapse from 'bootstrap/js/dist/collapse';
 import { useNavigate } from "react-router-dom";
 import { Modal, Button, Spinner } from "react-bootstrap";
@@ -121,7 +122,7 @@ const Ordenes = () => {
       return;
     }
     axios
-      .get("http://localhost:3000/ordenes/detalle", { headers: { Authorization: `Bearer ${token}` } })
+      .get(`${API_URL}/ordenes/detalle`, { headers: { Authorization: `Bearer ${token}` } })
       .then((res) => setOrdenes(res.data))
       .catch((error) => console.error(error));
   }, [token, navigate]);
@@ -130,7 +131,7 @@ const Ordenes = () => {
 
   const fetchOrdenesTree = useCallback(() => {
     return axios
-      .get("http://localhost:3000/ordenes/tree", {
+      .get(`${API_URL}/ordenes/tree`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => {
@@ -190,7 +191,7 @@ const Ordenes = () => {
   const handlePreviewPDF = useCallback(async (id) => {
     if (!id || !token) return;
     try {
-      const response = await fetch(`http://localhost:3000/ordenes/${id}/pdf`, {
+      const response = await fetch(`${API_URL}/ordenes/${id}/pdf`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -274,13 +275,13 @@ const Ordenes = () => {
     e.preventDefault();
     try {
       if (ordenSeleccionada) {
-        await axios.put(`http://localhost:3000/ordenes/${ordenSeleccionada.id}`, form, {
+        await axios.put(`${API_URL}/ordenes/${ordenSeleccionada.id}`, form, {
           headers: { Authorization: `Bearer ${token}` },
         });
         mostrarModalTemporal("Orden actualizada con éxito");
         setOrdenSeleccionada({ ...ordenSeleccionada, ...form });
       } else {
-        const { data } = await axios.post("http://localhost:3000/ordenes", form, {
+        const { data } = await axios.post(`${API_URL}/ordenes`, form, {
           headers: { Authorization: `Bearer ${token}` },
         });
         mostrarModalTemporal("Orden creada con éxito");
@@ -305,7 +306,7 @@ const Ordenes = () => {
     if (!confirmacion) return;
     
   try {
-      await axios.delete(`http://localhost:3000/ordenes/${ordenSeleccionada.id}`, {
+      await axios.delete(`${API_URL}/ordenes/${ordenSeleccionada.id}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       alert("Orden eliminada con éxito");
@@ -358,7 +359,7 @@ const Ordenes = () => {
       return;
     }
 
-    const url = `http://localhost:3000/ordenes/${id}/pdf${cliente ? "?cliente=true" : ""}`;
+    const url = `${API_URL}/ordenes/${id}/pdf${cliente ? "?cliente=true" : ""}`;
 
     try {
       setLoadingPDF(true);
@@ -411,7 +412,7 @@ const Ordenes = () => {
       data.append("existing", JSON.stringify(existing));
       data.append("layout", imagenesModal.length);
       const res = await axios.post(
-        `http://localhost:3000/ordenes/${ordenSeleccionada.id}/imagenes`,
+        `${API_URL}/ordenes/${ordenSeleccionada.id}/imagenes`,
         data,
         { headers: { Authorization: `Bearer ${token}` } }
       );
@@ -422,7 +423,7 @@ const Ordenes = () => {
         if (img.posicion >= 1 && img.posicion <= 5) {
           arr[img.posicion - 1] = {
             file: null,
-            preview: `http://localhost:3000${img.ruta}`,
+            preview: `${API_URL}${img.ruta}`,
           };
         }
       });
@@ -559,7 +560,7 @@ const Ordenes = () => {
                       if (img.posicion >= 1 && img.posicion <= 5) {
                         imgs[img.posicion - 1] = {
                           file: null,
-                          preview: `http://localhost:3000${img.ruta}`,
+                          preview: `${API_URL}${img.ruta}`,
                         };
                       }
                     });

--- a/frontend/frontend/src/apps/OrdenesExternas.jsx
+++ b/frontend/frontend/src/apps/OrdenesExternas.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import axios from 'axios';
+import { API_URL } from '../api';
 
 const OrdenesExternas = () => {
   const [form, setForm] = useState({ cliente: '', proyecto: '', figura: '' });
@@ -27,7 +28,7 @@ const OrdenesExternas = () => {
     data.append('figura', form.figura);
 
     try {
-      await axios.post('http://localhost:3000/ordenes-externas', data, {
+      await axios.post(`${API_URL}/ordenes-externas`, data, {
         headers: { Authorization: `Bearer ${token}` },
       });
       alert('Orden externa guardada');

--- a/frontend/frontend/src/apps/VerOFs.jsx
+++ b/frontend/frontend/src/apps/VerOFs.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import axios from "axios";
+import { API_URL } from "../api";
 import { Modal, Button } from "react-bootstrap";
 import {
   Package,
@@ -74,14 +75,14 @@ const VerOFs = () => {
   useEffect(() => {
     if (!token) return;
     axios
-      .get("http://localhost:3000/ordenes/all", {
+      .get(`${API_URL}/ordenes/all`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => setOrdenes(res.data))
       .catch((err) => console.error("Error obteniendo internas", err));
 
     axios
-      .get("http://localhost:3000/ordenes-externas/all", {
+      .get(`${API_URL}/ordenes-externas/all`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => setExternas(res.data))
@@ -240,7 +241,7 @@ const VerOFs = () => {
     if (!id || !token) return;
     try {
       setLoadingPDF(true);
-      const response = await fetch(`http://localhost:3000/ordenes/${id}/pdf`, {
+      const response = await fetch(`${API_URL}/ordenes/${id}/pdf`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -488,7 +489,7 @@ const VerOFs = () => {
                         </td>
                         <td>
                           <a
-                            href={`http://localhost:3000${o.pdf_path}`}
+                            href={`${API_URL}${o.pdf_path}`}
                             target="_blank"
                             rel="noreferrer"
                             className="btn btn-sm btn-outline-primary"

--- a/frontend/frontend/src/components/Chat.jsx
+++ b/frontend/frontend/src/components/Chat.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { io } from 'socket.io-client';
 import axios from 'axios';
+import { API_URL } from '../api';
 
 const Chat = () => {
   const [socket, setSocket] = useState(null);
@@ -18,13 +19,13 @@ const Chat = () => {
     setMyId(payload.id);
 
     axios
-      .get('http://localhost:3000/usuarios/list', {
+      .get(`${API_URL}/usuarios/list`, {
         headers: { Authorization: `Bearer ${token}` }
       })
       .then(res => setUsers(res.data))
       .catch(err => console.error(err));
 
-    const newSocket = io('http://localhost:3000', { auth: { token } });
+    const newSocket = io(API_URL, { auth: { token } });
     setSocket(newSocket);
 
     newSocket.on('private message', (msg) => {
@@ -39,12 +40,12 @@ const Chat = () => {
   const openConversation = async (userId) => {
     const token = localStorage.getItem('token');
     try {
-      const res = await axios.post('http://localhost:3000/conversaciones', { usuarioId: userId }, {
+      const res = await axios.post(`${API_URL}/conversaciones`, { usuarioId: userId }, {
         headers: { Authorization: `Bearer ${token}` }
       });
       setConversationId(res.data.id);
       setSelectedUser(userId);
-      const resMsgs = await axios.get(`http://localhost:3000/conversaciones/${res.data.id}/mensajes`, {
+      const resMsgs = await axios.get(`${API_URL}/conversaciones/${res.data.id}/mensajes`, {
         headers: { Authorization: `Bearer ${token}` }
       });
       setMessages(resMsgs.data);

--- a/frontend/frontend/src/components/ChatWidget.jsx
+++ b/frontend/frontend/src/components/ChatWidget.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { MessageCircle, SendHorizonal, ArrowLeft } from 'lucide-react';
 import { io } from 'socket.io-client';
 import axios from 'axios';
+import { API_URL } from '../api';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/ChatWidget.css';
 
@@ -25,14 +26,14 @@ const ChatWidget = () => {
     setMyId(payload.id);
 
     axios
-      .get('http://localhost:3000/usuarios/list', {
+      .get(`${API_URL}/usuarios/list`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then(res => setUsers(res.data))
       .catch(err => console.error(err));
 
     axios
-      .get('http://localhost:3000/conversaciones/unread', {
+      .get(`${API_URL}/conversaciones/unread`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then(res => {
@@ -44,7 +45,7 @@ const ChatWidget = () => {
       })
       .catch(err => console.error(err));
 
-    const newSocket = io('http://localhost:3000', { auth: { token } });
+    const newSocket = io(API_URL, { auth: { token } });
     setSocket(newSocket);
 
     return () => newSocket.disconnect();
@@ -81,7 +82,7 @@ const ChatWidget = () => {
     const token = localStorage.getItem('token');
     try {
       const res = await axios.post(
-        'http://localhost:3000/conversaciones',
+        `${API_URL}/conversaciones`,
         { usuarioId: user.id },
         { headers: { Authorization: `Bearer ${token}` } }
       );
@@ -89,12 +90,12 @@ const ChatWidget = () => {
       setSelectedUser(user);
       setUnread(prev => ({ ...prev, [user.id]: false }));
       const resMsgs = await axios.get(
-        `http://localhost:3000/conversaciones/${res.data.id}/mensajes`,
+        `${API_URL}/conversaciones/${res.data.id}/mensajes`,
         { headers: { Authorization: `Bearer ${token}` } }
       );
       setMessages(resMsgs.data);
       await axios.put(
-        `http://localhost:3000/conversaciones/${res.data.id}/read`,
+        `${API_URL}/conversaciones/${res.data.id}/read`,
         {},
         { headers: { Authorization: `Bearer ${token}` } }
       );
@@ -146,7 +147,7 @@ const ChatWidget = () => {
               >
                 <div className="me-2 rounded-circle bg-secondary text-white d-flex justify-content-center align-items-center" style={{ width: 32, height: 32 }}>
                   {user.avatar ? (
-                    <img src={`http://localhost:3000${user.avatar}`} alt={user.nombre} className="rounded-circle w-100 h-100" />
+                    <img src={`${API_URL}${user.avatar}`} alt={user.nombre} className="rounded-circle w-100 h-100" />
                   ) : (
                     <span>{user.nombre.charAt(0)}</span>
                   )}
@@ -171,7 +172,7 @@ const ChatWidget = () => {
             </button>
             <div className="me-2 rounded-circle bg-secondary text-white d-flex justify-content-center align-items-center" style={{ width: 32, height: 32 }}>
               {selectedUser.avatar ? (
-                <img src={`http://localhost:3000${selectedUser.avatar}`} alt={selectedUser.nombre} className="rounded-circle w-100 h-100" />
+                <img src={`${API_URL}${selectedUser.avatar}`} alt={selectedUser.nombre} className="rounded-circle w-100 h-100" />
               ) : (
                 <span>{selectedUser.nombre.charAt(0)}</span>
               )}

--- a/frontend/frontend/src/components/Login.js
+++ b/frontend/frontend/src/components/Login.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import axios from "axios";
+import { API_URL } from "../api";
 import { useNavigate } from "react-router-dom";
 import "../styles/Auth.css";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
@@ -18,7 +19,7 @@ const Login = () => {
     e.preventDefault();
     setError("");
     try {
-      const response = await axios.post("http://localhost:3000/login", form);
+      const response = await axios.post(`${API_URL}/login`, form);
       localStorage.setItem("token", response.data.token);
       localStorage.setItem("rol", response.data.rol);
       localStorage.setItem("username", response.data.nombre);

--- a/frontend/frontend/src/components/Register.js
+++ b/frontend/frontend/src/components/Register.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import axios from "axios";
+import { API_URL } from "../api";
 import { useNavigate } from "react-router-dom";
 import "../styles/Auth.css";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
@@ -37,7 +38,7 @@ const Register = () => {
     }
 
     try {
-      await axios.post("http://localhost:3000/register", form);
+      await axios.post(`${API_URL}/register`, form);
       alert("Usuario registrado con éxito");
       navigate("/login");
     } catch (error) {

--- a/frontend/frontend/src/pages/Dashboard.jsx
+++ b/frontend/frontend/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import axios from "axios";
+import { API_URL } from "../api";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "../styles/Dashboard.css";
 import Ordenes from "../apps/Ordenes";
@@ -33,7 +34,7 @@ const Dashboard = () => {
     }
 
     axios
-      .get(`http://localhost:3000/usuarios/${nombreUsuario}`, {
+      .get(`${API_URL}/usuarios/${nombreUsuario}`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((response) => {
@@ -76,10 +77,10 @@ const Dashboard = () => {
     e.preventDefault();
     const token = localStorage.getItem("token");
     try {
-      await axios.put(`http://localhost:3000/usuarios/${perfil.nombre}`, editData, {
+      await axios.put(`${API_URL}/usuarios/${perfil.nombre}`, editData, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      const res = await axios.get(`http://localhost:3000/usuarios/${editData.nombre}`, {
+      const res = await axios.get(`${API_URL}/usuarios/${editData.nombre}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       setPerfil(res.data);
@@ -192,7 +193,7 @@ const Dashboard = () => {
           </div>
           <div className="dropdown" ref={dropdownRef}>
             <img
-              src={perfil?.avatar ? `http://localhost:3000${perfil.avatar}` : "/silueta.jpg"}
+              src={perfil?.avatar ? `${API_URL}${perfil.avatar}` : "/silueta.jpg"}
               alt=""
               className="perfil-img dropdown-toggle"
               onClick={() => setMenuAbierto(!menuAbierto)}
@@ -226,7 +227,7 @@ const Dashboard = () => {
           {perfil && (
             <>
               <img
-                src={perfil.avatar ? `http://localhost:3000${perfil.avatar}` : "/silueta.jpg"}
+                src={perfil.avatar ? `${API_URL}${perfil.avatar}` : "/silueta.jpg"}
                 alt="avatar"
                 className="rounded-circle mb-3"
                 style={{ width: "100px", height: "100px", objectFit: "cover" }}


### PR DESCRIPTION
## Summary
- add API_URL env configuration for React frontend
- replace hard-coded localhost URLs with API_URL const

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e52c43f9c832ba2a95354787ca714